### PR TITLE
Remove `addresses` from card entity

### DIFF
--- a/_cards.md
+++ b/_cards.md
@@ -23,12 +23,6 @@ curl "https://api.bitreserve.org/v0/me/cards"
     "balance": "897.29",
     "available": "897.29",
     "lastTransactionAt": "2014-09-24T18:11:53.561Z",
-    "addresses": [
-      {
-        "id": "1GpBtJXXa1NdG94cYPGZTc3DfRY2P7EwzH",
-        "network": "bitcoin"
-      }
-    ],
     "settings": {
       "position": 1,
       "starred": true
@@ -44,16 +38,6 @@ curl "https://api.bitreserve.org/v0/me/cards"
     "balance": "0.00",
     "available": "0.00",
     "lastTransactionAt": "2014-07-07T05:40:46.624Z",
-    "addresses": [
-      {
-        "id": "1KHpy2xrscep4RiXPiM3jyjee82iBMyMan",
-        "network": "bitcoin"
-      },
-      {
-        "id": "18yFebPW8USkoBtYXeV6quwgnPGEVyvpKi",
-        "network": "bitcoin"
-      }
-    ],
     "settings": {
       "position": 7,
       "starred": true
@@ -92,12 +76,6 @@ curl "https://api.bitreserve.org/v0/me/cards/37e002a7-8508-4268-a18c-7335a6ddf24
   "balance": "42.82",
   "available": "42.82",
   "lastTransactionAt": "2014-06-16T20:46:51.002Z",
-  "addresses": [
-    {
-      "id": "145ZeN94MAtTmEgvhXEch3rRgrs7BdD2cY",
-      "network": "bitcoin"
-    }
-  ],
   "settings": {
     "position": 5,
     "starred": true

--- a/_entities.md
+++ b/_entities.md
@@ -19,12 +19,6 @@
     "position": 4,
     "starred": true
   },
-  "addresses": [
-    {
-      "id": "muABokE5awaCFtHWiw68rKGuSViBKDXLmH",
-      "network": "bitcoin"
-    }
-  ],
   "normalized": [
     {
       "available": "99.04",
@@ -45,7 +39,6 @@ id | A unique ID associated with the card.
 label | The display name of the card as chosen by the user.
 lastTransactionAt | A timestamp of the last time a transaction on this card was conducted.
 settings | Contains the card's current `position` and whether the card is `starred` or not.
-addresses | An associative array of all the known addresses associated with the card, including the primary card.
 normalized | Contains the normalized `available` and `balance` values in the currency set by the user in the settings.
 
 ## Contact Object

--- a/_users.md
+++ b/_users.md
@@ -83,12 +83,6 @@ curl "https://api.bitreserve.org/v0/me"
         "position": 1,
         "starred": true
       },
-      "addresses": [
-        {
-          "id": "mwvGZzRfgco7AVKajLkByGom5BTp6EMng7",
-          "network": "bitcoin"
-        }
-      ],
       "normalized": [
         {
           "available": "90.00",


### PR DESCRIPTION
This PR removes `addresses` from card entity since `addresses` and `address` are redundant.