### PR TITLE
Adds sandbox authentication url

### DIFF
--- a/_authentication.md
+++ b/_authentication.md
@@ -14,6 +14,10 @@ The authenticating web application should redirect users to the following URL:
 
 `https://uphold.com/authorize/<client_id>`
 
+Or for sandbox applications:
+
+`https://sandbox.uphold.com/authorize/<client_id>`
+
 Supported query parameters:
 
 Parameter | Required |  Description


### PR DESCRIPTION
There's a sandbox specific authentication url for the "web application flow" which this pull request documents. For sandbox applications `https://sandbox.uphold.com/authorize/<client_id>` works but `https://uphold.com/authorize/<client_id>` does not.