### PR TITLE
Add commit query param docs to create transaction call

### DIFF
--- a/_transactions.md
+++ b/_transactions.md
@@ -84,6 +84,10 @@ Upon preparing a transaction, a [Transaction Object](#transaction-object) will b
   You may only send value from addresses that you own.
 </aside>
 
+<aside class="notice">
+  Adding the query string parameter `?commit=1` to this request will create and commit the transaction in a single step.
+</aside>
+
 ### Request
 
 `POST https://api.uphold.com/v0/me/cards/:card/transactions`


### PR DESCRIPTION
As discussed [here](https://github.com/DanWebb/uphold-sdk-node/issues/3) a "commit" query string parameter can be added to the "create transaction" api call in order to create and commit a transaction in one step.

This was certainly helpful for my use case and wouldn't have known about unless Jorge mentioned it so feel it should be documented somewhere.