### PR TITLE
Add new oauth scopes for transactions

### DIFF
--- a/_applications.md
+++ b/_applications.md
@@ -28,8 +28,12 @@ cards:read | Can view all [cards](#card-object) and their information.
 cards:write | Can create and update any [card](#card-object).
 contacts:read | Can view all [contacts](#contact-object) and their information.
 contacts:write | Can create and update any [contact](#contact-object).
+transactions:deposit | Can create a deposit [transaction](#transaction-object).
 transactions:read | Can view any [transaction](#transaction-object).
-transactions:write | Can create a [transaction](#transaction-object) from any card to any destination (another card or an external address), cancel and resend transactions.
+transactions:send | Can create a [transaction](#transaction-object) between different users (including invites).
+transactions:transfer | Can create a [transaction](#transaction-object) between a user's cards.
+transactions:withdraw | Can create a withdrawal [transaction](#transaction-object).
+transactions:write | Can create a [transaction](#transaction-object) from any card to any destination (another card or an external address), cancel and resend transactions. This scope will be deprecated in the future in favor of the more fine-grained write scopes above (deposit, send, transfer and withdraw).
 user:read | Can view the [user](#user-object) and their information.
 
 <aside class="notice">


### PR DESCRIPTION
Add the 4 new transaction scopes and warn that `transactions:write` will be deprecated in the future.