### PR TITLE
Fix required description parameter

### DIFF
--- a/_authentication.md
+++ b/_authentication.md
@@ -107,7 +107,7 @@ Supported parameters:
 
 Parameter   | Required | Description
 ----------- | -------- | -----------------------------------------
-description | no       | A human-readable description of this PAT.
+description | yes      | A human-readable description of this PAT.
 
 <aside class="notice">
   <strong>Import Notice</strong>: This request must be authenticated with your username and password using the HTTP Basic Authentication scheme.


### PR DESCRIPTION
When generating a new _PAT_, the `description` parameter is actually required.