### PR TITLE
Fix `normalized` field in card entity

### DIFF
--- a/_entities.md
+++ b/_entities.md
@@ -61,7 +61,7 @@ label             | The display name of the card as chosen by the user.
 lastTransactionAt | A timestamp of the last time a transaction on this card was conducted.
 settings          | Contains the card's current `position` and whether the card is `starred` or not.
 addresses         | An associative array of all the known addresses associated with the card, including the primary card.
-normalized        | Contains the normalized `available` and `balance` values in USD.
+normalized        | Contains the normalized `available` and `balance` values in the currency set by the user in the settings.
 
 ## Contact Object
 > An example contact encoded in JSON looks like this:


### PR DESCRIPTION
Corrected the references of the `normalized` property in the card entity which stated incorrectly that it was a representation of values in `USD`. These values are actually represented in the currency set in the user's settings.

/cc @ruimarinho