### PR TITLE
Update transaction type changes

### DIFF
--- a/_entities.md
+++ b/_entities.md
@@ -180,7 +180,7 @@ Transactions record the movement of value into, within and out of the Uphold net
 Property     | Description
 ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 id           | A unique ID on the Uphold Network associated with the transaction.
-type         | The nature of the transaction. Possible values are `deposit`, `transfer` and `withdrawal`.
+type         | The nature of the transaction. Possible values are `deposit`, `internal`, `transfer` and `withdrawal`.
 message      | A message or note provided by the user at the time the transaction was initiated, with the intent of communicating additional information and context about the nature/purpose of the transaction.
 denomination | The funds to be transferred, as originally requested. See "Denomination" below.
 fees         | The fees that were applied to the transaction.

--- a/_transactions.md
+++ b/_transactions.md
@@ -88,8 +88,11 @@ The following table describes the types of transactions currently supported:
 Type       | Origin                     | Destination
 ---------- | -------------------------- | -------------------------------------------------------
 deposit    | _ACH_ or _SEPA_ account id | Uphold card id
+internal   | Uphold card id             | Uphold card id from the same user
 withdrawal | Uphold card id             | _ACH_, _SEPA_ or _Bitcoin_ address
-transfer   | Uphold card id             | An email address, an application id, an Uphold username or an Uphold card id
+transfer   | Uphold card id             | An email address, an application id, an Uphold username or an Uphold card id from a different user
+
+<aside class="notice">Note the difference between `internal` and `transfer` is essentially the destination user.</aside>
 
 Upon preparing a transaction, a [Transaction Object](#transaction-object) will be returned with a newly-generated `id`.
 <aside class="notice">
@@ -317,7 +320,7 @@ curl -X GET "https://api.uphold.com/v0/reserve/transactions"
     "type": "transfer"
   },
   "status": "completed",
-  "type": "transfer",
+  "type": "internal",
   "normalized": [{
     "fee": "0.00",
     "rate": "0.91759",
@@ -465,7 +468,7 @@ curl -X GET "https://api.uphold.com/v0/reserve/transactions/a97bb994-6e24-4a89-b
     "rate": "1.00"
   },
   "status": "cancelled",
-  "type": "transfer",
+  "type": "internal",
   "origin": {
     "amount": "1.00",
     "base": "1.00",

--- a/_transparency.md
+++ b/_transparency.md
@@ -465,6 +465,54 @@ Given that this is a point in the chain at which there is a genesis of value, th
 }
 </code></pre>
 
+### Transfers
+A transfer documents movement of value within our network, between two parties or two denominations, or both.
+<pre class="inline"><code>{
+  "id": "1571fbef-d34e-447c-9b6e-4ad775953082",
+  "type": "transfer",
+  "params": {
+    "currency": "USD",
+    "margin": "0.45",
+    "pair": "BTCUSD",
+    "rate": "392.16000",
+    "txid": "1946783b396998f8f91c984431ecfecff6d0a72db68b32d0873c1024c7279254"
+  },
+  "denomination": {
+    "amount": "1.3",
+    "currency": "BTC"
+  },
+  "origin": {
+    "amount": "1.3001",
+    "base": "1.3",
+    "commission": "0.00",
+    "currency": "BTC",
+    "fee": "0.0001",
+    "rate": "0.00255",
+    "sources": [{
+      "id": "61cdccdf-cb6e-414e-aafc-7c42dc375cf6",
+      "amount": "0.73327414"
+    }, {
+      "id": "34f87520-49a4-4f46-8ee0-ba0522c06aa1",
+      "amount": "0.56682586"
+    }]
+  },
+  "destination": {
+    "amount": "507.51",
+    "base": "509.81",
+    "commission": "2.30",
+    "currency": "USD",
+    "fee": "0.00",
+    "rate": "392.16000"
+  },
+  "status": "completed",
+  "createdAt": "2014-09-30T20:29:36.458Z"
+}
+</code></pre>
+
+<aside class="notice">
+  If the transfer is between cards of the same user, the `transaction.type` will be marked as `internal`.
+</aside>
+
 ### Withdrawals
 Withdrawal documents the flow of assets out of the system. The destination of the transaction would refer as completely as it can to any external sources that the Uphold transaction can be correlated against/with.
 
@@ -506,50 +554,6 @@ Withdrawals also account for value leaving the Reservechain, and is thus a termi
   },
   "status": "completed",
   "createdAt": "2014-10-08T06:53:51.060Z"
-}
-</code></pre>
-
-### Transfers
-A transfer documents movement of value within our network, either between two parties or two denominations, or both.
-<pre class="inline"><code>{
-  "id": "1571fbef-d34e-447c-9b6e-4ad775953082",
-  "type": "transfer",
-  "params": {
-    "currency": "USD",
-    "margin": "0.45",
-    "pair": "BTCUSD",
-    "rate": "392.16000",
-    "txid": "1946783b396998f8f91c984431ecfecff6d0a72db68b32d0873c1024c7279254"
-  },
-  "denomination": {
-    "amount": "1.3",
-    "currency": "BTC"
-  },
-  "origin": {
-    "amount": "1.3001",
-    "base": "1.3",
-    "commission": "0.00",
-    "currency": "BTC",
-    "fee": "0.0001",
-    "rate": "0.00255",
-    "sources": [{
-      "id": "61cdccdf-cb6e-414e-aafc-7c42dc375cf6",
-      "amount": "0.73327414"
-    }, {
-      "id": "34f87520-49a4-4f46-8ee0-ba0522c06aa1",
-      "amount": "0.56682586"
-    }]
-  },
-  "destination": {
-    "amount": "507.51",
-    "base": "509.81",
-    "commission": "2.30",
-    "currency": "USD",
-    "fee": "0.00",
-    "rate": "392.16000"
-  },
-  "status": "completed",
-  "createdAt": "2014-09-30T20:29:36.458Z"
 }
 </code></pre>
 


### PR DESCRIPTION
This PR adds the changes in our `transaction.type`, i.e. the difference between `internal` and `transfer` transactions.
