### PR TITLE
Update rate limit headers

### DIFF
--- a/_ratelimits.md
+++ b/_ratelimits.md
@@ -23,12 +23,12 @@ POST /users                               |         10 / 10-min window |        
 ## Response Headers
 The current rate limit in effect is explained via custom HTTP headers as described in the table below. Additionally, the standard HTTP `Retry-After` header field will be appended when the rate limit is exhausted and indicates, in delta-seconds, how long until the rate limit window is reset.
 
-Header                | Description
---------------------- | ----------------------------------------------------------------------------------------------------------------------
-X-RateLimit-Limit     | The total number of requests possible in the current window duration
-X-RateLimit-Remaining | The number of requests remaining in the current window duration
-X-RateLimit-Reset     | The time, in UTC [epoch seconds](http://en.wikipedia.org/wiki/Unix_time), until the end of the current window duration
-Retry-After           | The time, in seconds, until the end of the current window duration
+Header               | Description
+-------------------- | ----------------------------------------------------------------------------------------------------------------------
+Rate-Limit-Total     | The total number of requests possible in the current window duration
+Rate-Limit-Remaining | The number of requests remaining in the current window duration
+Rate-Limit-Reset     | The time, in UTC [epoch seconds](http://en.wikipedia.org/wiki/Unix_time), until the end of the current window duration
+Retry-After          | The time, in seconds, until the end of the current window duration
 
 > Example request:
 
@@ -39,9 +39,9 @@ curl -I -X GET "https://api.uphold.com/v0/ticker"
 > Rate limit details on response headers:
 
 ```
-X-RateLimit-Limit: 300
-X-RateLimit-Remaining: 299
-X-RateLimit-Reset: 1422288284
+Rate-Limit-Total: 300
+Rate-Limit-Remaining: 299
+Rate-Limit-Reset: 1422288284
 ```
 
 When the API limit is reached, a status code of [429 Too Many Requests](http://tools.ietf.org/html/rfc6585#section-4) is returned with the aforementioned `Retry-After` header:
@@ -51,17 +51,17 @@ When the API limit is reached, a status code of [429 Too Many Requests](http://t
 ```
 HTTP/1.1 429 Too Many Requests
 
-X-RateLimit-Limit: 300
-X-RateLimit-Remaining: 0
-X-RateLimit-Reset: 1422288284
+Rate-Limit-Total: 300
+Rate-Limit-Remaining: 0
+Rate-Limit-Reset: 1422288284
 Retry-After: 85
 ```
 
 In this this example, the request could be retried in 1 minute and 25 seconds.
 
-Alternatively, the `X-RateLimit-Reset` header could also be used to calculate when to retry the request:
+Alternatively, the `Rate-Limit-Reset` header could also be used to calculate when to retry the request:
 
-> Parsing _X-RateLimit-Reset_:
+> Parsing _Rate-Limit-Reset_:
 
 ```js
 console.log(new Date(1422288199 * 1000));


### PR DESCRIPTION
Resolves https://github.com/uphold/docs/issues/111.

This PR updates our docs with the new rate limit headers. Here's the conversion from the old ones to the new ones:

```
X-RateLimit-Remaining -> Rate-Limit-Remaining
X-RateLimit-Reset -> Rate-Limit-Reset
X-RateLimit-Limit -> Rate-Limit-Total
```

The old headers are still provided in API responses but are now deprecated, and no longer show up in these docs.