### PR TITLE
Remove broken link from support section

### DIFF
--- a/_support.md
+++ b/_support.md
@@ -1,4 +1,4 @@
 # Support
-Please visit our [developer community](https://developer.uphold.com/en/community) where you can seek support from fellow developers as well as the developer support professionals at Uphold. If you need to contact us directly, please email <a href="mailto:developer@uphold.com?Subject=Help%20Me" target="_top">developer@uphold.com</a>
+Need help, or have a question? Contact <a href="mailto:developer@uphold.com?Subject=Help%20Me" target="_top">developer@uphold.com</a>.
 
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>


### PR DESCRIPTION
There was a link to a community page that no longer exists. The rest of the copy was adapted to be consistent with how we have it elsewhere.