### PR TITLE
Fix `method-id` documentation

### DIFF
--- a/_authentication.md
+++ b/_authentication.md
@@ -174,6 +174,7 @@ curl https://api.uphold.com/v0/me/tokens \
   -X POST \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
+  -H "OTP-Method-Id: <Method-Id>" \
   -H "OTP-Token: <OTP-Token>" \
   -d '{ "description": "My command line script" }'
 ```
@@ -198,9 +199,8 @@ Parameter   | Required | Description
 ----------- | -------- | -----------------------------------------
 description | yes      | A human-readable description of this PAT.
 
-<aside class="notice">
-  <strong>Important Notice</strong>: This request must be authenticated via OAuth, and a valid OTP token via the `OTP-Token` header.
-</aside>
+<aside class="notice">Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.</aside>
+<aside class="notice">Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.</aside>
 
 ### Revoking a PAT
 > To revoke a Personal Access Token, execute the following command:
@@ -238,6 +238,7 @@ The `<token>` should be set as the `accessToken` received during creation.
 
 ```bash
 curl https://api.uphold.com/v0/me \
+  -H 'OTP-Method-Id: <Method-Id>' \
   -H 'OTP-Token: <OTP-Token>' \
   -u <username-or-email>:<password>
 ```

--- a/_totp.md
+++ b/_totp.md
@@ -116,7 +116,8 @@ curl https://api.uphold.com/v0/me/authentication_methods/3f8f8264-2f5e-4b2b-8333
   -X DELETE \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -H 'OTP-Token: <OTP-Token>'
+  -H "OTP-Method-Id: <Method-Id>" \
+  -H "OTP-Token: <OTP-Token>"
 ```
 
 > The above command does not return a JSON response.
@@ -125,7 +126,9 @@ curl https://api.uphold.com/v0/me/authentication_methods/3f8f8264-2f5e-4b2b-8333
 
 `DELETE https://api.uphold.com/v0/me/authentication_methods/3f8f8264-2f5e-4b2b-8333-473715ab039a`
 
-<aside class="notice">Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token for an existing authentication method that is verified. You cannot delete all of a user's authentication methods as trying to delete the last verified method of a user will return an error.</aside>
+<aside class="notice">Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.</aside>
+<aside class="notice">Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.</aside>
+<aside class="notice">You cannot delete all of a user's authentication methods as trying to delete the last verified method of a user will return an error.</aside>
 
 ### Response
 

--- a/_totp.md
+++ b/_totp.md
@@ -1,6 +1,6 @@
-# Time-Based One-Time Password (TOTP)
+# One-Time Password
 
-Uphold provides a TOTP mechanism to secure user accounts. Adopting and adhering to this mechanism is recommended for safety reasons.
+Uphold provides a TOTP (Time-Based One-Time Password) mechanism to secure user accounts. Adopting and adhering to this mechanism is recommended for safety reasons.
 The following section documents how the Authentication Methods API works to provide support for this security mechanism.
 
 ## List Authentication Methods


### PR DESCRIPTION
This PR improves our API documentation as it is currently missing `method-id` information.

It also fixes the TOTP name to better fit our navigation side-bar.

Fixes [164](https://github.com/uphold/docs/issues/164).