### PR TITLE
Add documentation on password reset restriction

### DIFF
--- a/_applications.md
+++ b/_applications.md
@@ -10,6 +10,7 @@ Developers will need to [register their application](https://support.uphold.com/
 - Likewise, the provided _Redirect URL_ when registering the application must be a valid static subresource. Notice that this property cannot be dynamically reconfigured during authorization requests for security reasons.
 - The _Redirect URL_ can also be a valid URI with a non-http/https protocol which is useful for mobile and desktop applications, for example: `my-app://uphold/connect`.
 - Users can revoke access to your application at any time. Your application **must** be prepared for this and, if necessary, should request authorization from the user again.
+- Likewise, when users change their password, all authorization tokens are expired and the user enters a cool-down period where outbound transactions are not allowed, for security reasons. Your application **must** be prepared for this.
 - Your application may be suspended in an automated fashion in accordance with our [Terms of Service](https://uphold.com/en/legal/membership-agreement).
 - Standard [rate limits](#rate-limits) apply to all issued access tokens.
 

--- a/_transactions.md
+++ b/_transactions.md
@@ -154,6 +154,7 @@ Once a transaction has been created and a quote secured, commit the transaction 
 ### Request
 `POST https://api.uphold.com/v0/me/cards/:card/transactions/:id/commit`
 <aside class="notice">Requires any of the following scopes, based on the type of transaction being committed: `transactions:deposit`, `transactions:transfer:application`, `transactions:transfer:others`, `transactions:transfer:self` or `transactions:withdraw` for Uphold Connect applications.</aside>
+<aside class="notice">If the user has recently changed their password, they may be in a cool-down period where outbound transactions are not allowed, for security reasons. This results in a 400 HTTP error with code <code>password_reset_restriction</code>. Your application must be prepared to handle this failure scenario.</aside>
 
 ### Response
 Returns a [Transaction Object](#transaction-object).


### PR DESCRIPTION
It is important that our partners are aware that perfectly valid transactions may fail because the user is in a cool-down period because of a recent password change. This PR updates the documentation to raise that awareness, indicating the validation error code they should look for.