### PR TITLE
Fix webhooks bullet points

### DIFF
--- a/_webhooks.md
+++ b/_webhooks.md
@@ -2,8 +2,8 @@
 For **business usage only** you may choose to use webhooks to get updates in real time instead of having to poll the API. This requires manual approval from Uphold.
 
 A webhooks integration requires the following details:
-- **Subscription URL:** the URL for Uphold to send webhook requests to;
-- **Secret:** the secret for Uphold to use to sign all requests and prove they have not been tampered (not the same as the client secret that is used for Uphold's API).
+* **Subscription URL:** the URL for Uphold to send webhook requests to;
+* **Secret:** the secret for Uphold to use to sign all requests and prove they have not been tampered (not the same as the client secret that is used for Uphold's API).
 
 Each webhook uses the following format:
 


### PR DESCRIPTION
Using `-`, [GitHub](https://github.com/uphold/docs/blob/c579a2d76f2358fd96e375824a6827aca1a5c1dc/_webhooks.md) shows bullet points correctly, but [Slate](https://uphold.com/en/developer/api/documentation/#webhooks) doesn't.

According to [their documentation](https://github.com/lord/slate/wiki/Markdown-Syntax), we need to replace `-` with `*` to get bullet points to work as expected in Slate.