### PR TITLE
Update image resources

### DIFF
--- a/_applications.md
+++ b/_applications.md
@@ -50,32 +50,14 @@ transactions:write | Can create a [transaction](#transaction-object) from any or
 ## Resources
 We prefer that you use these image resources when connecting your applications to Uphold.
 
-<img alt="Connect Button" src="images/buttons/uphold-connect-white@1x.png" srcset="images/buttons/uphold-connect-white@1x.png 1x, images/buttons/uphold-connect-white@2x.png 2x"><br> [small (125x41)](images/buttons/uphold-connect-white@1x.png), [large (249x82)](images/buttons/uphold-connect-white@2x.png)
+<img alt="Connect" src="images/buttons/green_bg/connect.png" srcset="images/buttons/green_bg/connect.png 1x, images/buttons/green_bg/connect@2x.png 2x"><br> [small (129x40)](images/buttons/green_bg/connect.png), [large (258x80)](images/buttons/green_bg/connect@2x.png), [vector (SVG)](images/buttons/green_bg/connect.svg)
 
-<img alt="Connect Button" src="images/buttons/uphold-connect-with-white@1x.png" srcset="images/buttons/uphold-connect-with-white@1x.png 1x, images/buttons/uphold-connect-with-white@2x.png 2x"><br> [small (206x41)](images/buttons/uphold-connect-with-white@1x.png), [large (412x82)](images/buttons/uphold-connect-with-white@2x.png)
+<img alt="Connect with Uphold" src="images/buttons/green_bg/connect_with_uphold.png" srcset="images/buttons/green_bg/connect_with_uphold.png 1x, images/buttons/green_bg/connect_with_uphold@2x.png 2x"><br> [small (206x40)](images/buttons/green_bg/connect_with_uphold.png), [large (412x80)](images/buttons/green_bg/connect_with_uphold@2x.png), [vector (SVG)](images/buttons/green_bg/connect_with_uphold.svg)
 
-<img alt="Connect Button" src="images/buttons/uphold-powered-white@1x.png" srcset="images/buttons/uphold-powered-white@1x.png 1x, images/buttons/uphold-powered-white@2x.png 2x"><br> [small (199x41)](images/buttons/uphold-powered-white@1x.png), [large (397x82)](images/buttons/uphold-powered-white@2x.png)
+<img alt="Powered by Uphold" src="images/buttons/green_bg/powered_by_uphold.png" srcset="images/buttons/green_bg/powered_by_uphold.png 1x, images/buttons/green_bg/powered_by_uphold@2x.png 2x"><br> [small (199x40)](images/buttons/green_bg/powered_by_uphold.png), [large (398x80)](images/buttons/green_bg/powered_by_uphold@2x.png), [vector (SVG)](images/buttons/green_bg/powered_by_uphold.svg)
 
-<img alt="Connect Button" src="images/buttons/uphold-connect-gray@1x.png" srcset="images/buttons/uphold-connect-gray@1x.png 1x, images/buttons/uphold-connect-gray@2x.png 2x"><br> [small (125x41)](images/buttons/uphold-connect-gray@1x.png), [large (249x82)](images/buttons/uphold-connect-gray@2x.png)
+<img alt="Connect" src="images/buttons/white_bg/connect.png" srcset="images/buttons/white_bg/connect.png 1x, images/buttons/white_bg/connect@2x.png 2x"><br> [small (129x40)](images/buttons/white_bg/connect.png), [large (258x80)](images/buttons/white_bg/connect@2x.png), [vector (SVG)](images/buttons/white_bg/connect.svg)
 
-<img alt="Connect Button" src="images/buttons/uphold-connect-with-gray@1x.png" srcset="images/buttons/uphold-connect-with-gray@1x.png 1x, images/buttons/uphold-connect-with-gray@2x.png 2x"><br> [small (206x41)](images/buttons/uphold-connect-with-gray@1x.png), [large (412x82)](images/buttons/uphold-connect-with-gray@2x.png)
+<img alt="Connect with Uphold" src="images/buttons/white_bg/connect_with_uphold.png" srcset="images/buttons/white_bg/connect_with_uphold.png 1x, images/buttons/white_bg/connect_with_uphold@2x.png 2x"><br> [small (206x40)](images/buttons/white_bg/connect_with_uphold.png), [large (412x80)](images/buttons/white_bg/connect_with_uphold@2x.png), [vector (SVG)](images/buttons/white_bg/connect_with_uphold.svg)
 
-<img alt="Connect Button" src="images/buttons/uphold-powered-gray@1x.png" srcset="images/buttons/uphold-powered-gray@1x.png 1x, images/buttons/uphold-powered-gray@2x.png 2x"><br> [small (199x41)](images/buttons/uphold-powered-gray@1x.png), [large (397x82)](images/buttons/uphold-powered-gray@2x.png)
-
-<img alt="Connect Button" src="images/buttons/uphold-connect-green@1x.png" srcset="images/buttons/uphold-connect-green@1x.png 1x, images/buttons/uphold-connect-green@2x.png 2x"><br> [small (124x40)](images/buttons/uphold-connect-green@1x.png), [large (247x80)](images/buttons/uphold-connect-green@2x.png)
-
-<img alt="Connect Button" src="images/buttons/uphold-connect-with-green@1x.png" srcset="images/buttons/uphold-connect-with-green@1x.png 1x, images/buttons/uphold-connect-with-green@2x.png 2x"><br> [small (205x40)](images/buttons/uphold-connect-with-green@1x.png), [large (410x80)](images/buttons/uphold-connect-with-green@2x.png)
-
-<img alt="Connect Button" src="images/buttons/uphold-powered-green@1x.png" srcset="images/buttons/uphold-powered-green@1x.png 1x, images/buttons/uphold-powered-green@2x.png 2x"><br> [small (198x40)](images/buttons/uphold-powered-green@1x.png), [large (395x80)](images/buttons/uphold-powered-green@2x.png)
-
-<img alt="Connect Button" src="images/buttons/uphold-connect-white-gray@1x.png" srcset="images/buttons/uphold-connect-white-gray@1x.png 1x, images/buttons/uphold-connect-white-gray@2x.png 2x"><br> [small (125x41)](images/buttons/uphold-connect-white-gray@1x.png), [large (249x82)](images/buttons/uphold-connect-white-gray@2x.png)
-
-<img alt="Connect Button" src="images/buttons/uphold-connect-with-white-gray@1x.png" srcset="images/buttons/uphold-connect-with-white-gray@1x.png 1x, images/buttons/uphold-connect-with-white-gray@2x.png 2x"><br> [small (206x41)](images/buttons/uphold-connect-with-white-gray@1x.png), [large (412x82)](images/buttons/uphold-connect-with-white-gray@2x.png)
-
-<img alt="Connect Button" src="images/buttons/uphold-powered-white-gray@1x.png" srcset="images/buttons/uphold-powered-white-gray@1x.png 1x, images/buttons/uphold-powered-white-gray@2x.png 2x"><br> [small (199x41)](images/buttons/uphold-powered-white-gray@1x.png), [large (397x82)](images/buttons/uphold-powered-white-gray@2x.png)
-
-<img alt="Connect Button" src="images/buttons/uphold-powered-transparent@1x.png" srcset="images/buttons/uphold-powered-transparent@1x.png 1x, images/buttons/uphold-powered-transparent@2x.png 2x"><br> [small (129x50)](images/buttons/uphold-powered-transparent@1x.png), [large (258x100)](images/buttons/uphold-powered-transparent@2x.png)
-
-<img alt="Connect Button" src="images/buttons/uphold-powered-transparent-green@1x.png" srcset="images/buttons/uphold-powered-transparent-green@1x.png 1x, images/buttons/uphold-powered-transparent-green@2x.png 2x"><br> [small (129x50)](images/buttons/uphold-powered-transparent-green@1x.png), [large (258x100)](images/buttons/uphold-powered-transparent-green@2x.png)
-
-<img alt="Connect Button" src="images/buttons/uphold-powered-transparent-gray@1x.png" srcset="images/buttons/uphold-powered-transparent-gray@1x.png 1x, images/buttons/uphold-powered-transparent-gray@2x.png 2x"><br> [small (129x50)](images/buttons/uphold-powered-transparent-gray@1x.png), [large (258x100)](images/buttons/uphold-powered-transparent-gray@2x.png)
+<img alt="Powered by Uphold" src="images/buttons/white_bg/powered_by_uphold.png" srcset="images/buttons/white_bg/powered_by_uphold.png 1x, images/buttons/white_bg/powered_by_uphold@2x.png 2x"><br> [small (199x40)](images/buttons/white_bg/powered_by_uphold.png), [large (398x80)](images/buttons/white_bg/powered_by_uphold@2x.png), [vector (SVG)](images/buttons/white_bg/powered_by_uphold.svg)


### PR DESCRIPTION
Update button images to use the new logo. In addition, vector images of the buttons are provided as well.

**Note:** This PR should be merged in coordination with https://github.com/uphold/slate/pull/61.