### PR TITLE
Fix JSON syntax in various files

### DIFF
--- a/_transactions.md
+++ b/_transactions.md
@@ -7,7 +7,7 @@ curl https://api.uphold.com/v0/me/cards/a6d35fcd-xxxx-9c9d1dda6d57/transactions 
   -X POST \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -d '{ "denomination": { "amount": 0.1, "currency": "USD" }, "destination": "foo@bar.com" }'
+  -d '{ "denomination": { "amount": "0.1", "currency": "USD" }, "destination": "foo@bar.com" }'
 ```
 
 > The above command returns the following JSON:
@@ -39,7 +39,7 @@ curl https://api.uphold.com/v0/me/cards/a6d35fcd-xxxx-9c9d1dda6d57/transactions 
       }
     },
     "rate": "0.85620",
-    "type": "card",
+    "type": "card"
   },
   "fees": [{
     "amount": "0.04",

--- a/_transparency.md
+++ b/_transparency.md
@@ -392,7 +392,7 @@ Uphold may decide to secure the value of its Reserve by holding value in asset c
     "amount": "1",
     "currency": "T-Bill"
     "meta": {
-      "maturityDate": '2016-05-01 00:00:00 UTC',
+      "maturityDate": "2016-05-01 00:00:00 UTC",
       "principal": 1000000,
       "rate": 1.5,
       "cusip": 345370860
@@ -504,7 +504,7 @@ Withdrawals also account for value leaving the Reservechain, and is thus a termi
     "commission": "0.00",
     "currency": "BTC",
     "fee": "0.00",
-    "rate": "1.00",
+    "rate": "1.00"
   },
   "status": "completed",
   "createdAt": "2014-10-08T06:53:51.060Z"


### PR DESCRIPTION
- Change transaction creation example to quote floating point number as a string
- Fix output of date object to use double quotes instead of single quotes
- Remove trailing commas