### PR TITLE
Document query string filters

### DIFF
--- a/_accounts.md
+++ b/_accounts.md
@@ -1,7 +1,9 @@
 # Accounts
+
 Uphold allows users to deposit value into a specific card from an external source (ACH account, debit/credit card or wire transfer) or withdraw to an external source (ACH account or wire transfer).
 
-Whenever a deposit is made into an Uphold card, it will be automatically converted into the value determined by the card's denomination. Likewise, when a withdrawal is made, the currency will be converted to the currency of the destination account, thus minimizing fees and currency conversions.
+Whenever a deposit is made into an Uphold card, it will be automatically converted into the value determined by the card's denomination.
+Likewise, when a withdrawal is made, the currency will be converted to the currency of the destination account, thus minimizing fees and currency conversions.
 
 We support the following account types:
 
@@ -56,7 +58,9 @@ curl https://api.uphold.com/v0/me/accounts?q=type:sepa,card
 Retrieves a list of accounts for the current user.
 
 ### Request
+
 `GET https://api.uphold.com/v0/me/accounts`
+
 <aside class="notice">Requires the `accounts:read` scope for Uphold Connect applications.</aside>
 
 You can filter the list of returned accounts using query string parameters.
@@ -65,6 +69,7 @@ For a list of valid values for these parameters, refer to the [Account Object](#
 See the code to the right for an example.
 
 ### Response
+
 Returns an array of the current user's accounts.
 
 ## Get Account Details
@@ -90,9 +95,12 @@ curl https://api.uphold.com/v0/me/accounts/18843b6d-5a43-480f-8e2b-73b27d726bf0 
 Retrieves the details about a specific account.
 
 ### Request
+
 `GET https://api.uphold.com/v0/me/accounts/:id`
+
 <aside class="notice">Requires the `accounts:read` scope for Uphold Connect applications.</aside>
 <aside class="notice">The account id must be owned by the user performing the API call.</aside>
 
 ### Response
+
 Returns a fully formed [Account Object](#account-object) representing the requested account.

--- a/_accounts.md
+++ b/_accounts.md
@@ -15,8 +15,17 @@ Please refer to our FAQ for estimated [ACH transaction times](https://support.up
 
 ## List Accounts
 
+> The basic request to this endpoint lists all accounts for the current user:
+
 ```bash
 curl https://api.uphold.com/v0/me/accounts \
+  -H "Authorization: Bearer <token>"
+```
+
+> This list can be filtered. For example, to list only accounts of the `sepa` or `card` types, you can specify the types in the query string, like so:
+
+```bash
+curl https://api.uphold.com/v0/me/accounts?q=type:sepa,card
   -H "Authorization: Bearer <token>"
 ```
 
@@ -49,6 +58,11 @@ Retrieves a list of accounts for the current user.
 ### Request
 `GET https://api.uphold.com/v0/me/accounts`
 <aside class="notice">Requires the `accounts:read` scope for Uphold Connect applications.</aside>
+
+You can filter the list of returned accounts using query string parameters.
+Supported filters are `status:` and `type:`, with either a single value or a comma-separated list.
+For a list of valid values for these parameters, refer to the [Account Object](#account-object) documentation.
+See the code to the right for an example.
 
 ### Response
 Returns an array of the current user's accounts.

--- a/_cards.md
+++ b/_cards.md
@@ -1,6 +1,12 @@
 # Cards
 
-Uphold uses the concept of a "card" as a store of value. Each card is denominated by a currency or store of value, and every card is automatically provisioned one or more addresses to which value can be sent. Whenever value flows into a card, Uphold automatically converts that value into the value determined by the card's denomination. In the world of bitcoin for example, this allows one to preserve the original value sent by the sender and shields the recipient from any volatility they might be exposed to by holding bitcoin directly. This also allows recipients of funds to normalize all incoming funds to a single store of value regardless of how the value was originally sent.
+Uphold uses the concept of a "card" as a store of value.
+Each card is denominated by a currency or store of value, and every card is automatically provisioned one or more addresses to which value can be sent.
+(Note that there can be multiple cards for the same currency.)
+
+Whenever value flows into a card, Uphold automatically converts that value into the value determined by the card's denomination.
+In the world of bitcoin, for example, this allows one to preserve the original value sent by the sender, and shields the recipient from any volatility they might be exposed to by holding bitcoin directly.
+This also allows recipients of funds to normalize all incoming funds to a single store of value, regardless of how the value was originally sent.
 
 ## List Cards
 

--- a/_cards.md
+++ b/_cards.md
@@ -4,8 +4,17 @@ Uphold uses the concept of a "card" as a store of value. Each card is denominate
 
 ## List Cards
 
+> The basic request to this endpoint lists all cards for the current user:
+
 ```bash
 curl https://api.uphold.com/v0/me/cards \
+  -H "Authorization: Bearer <token>"
+```
+
+> This list can be filtered. For example, to list only cards denominated in BTC or EUR, you can specify the currencies in the query string, like so:
+
+```bash
+curl https://api.uphold.com/v0/me/cards?q=currency:BTC,EUR
   -H "Authorization: Bearer <token>"
 ```
 
@@ -63,6 +72,10 @@ Retrieves a list of cards for the current user.
 `GET https://api.uphold.com/v0/me/cards`
 
 <aside class="notice">Requires the <code>cards:read</code> scope for Uphold Connect applications.</aside>
+
+You can filter the list of returned cards using query string parameters.
+Supported filters are `currency:` (which accepts a comma-separated list of currencies) and `settings.starred:` (which accepts `true` or `false`).
+See the code to the right for an example.
 
 This endpoint supports [Pagination](#pagination).
 


### PR DESCRIPTION
Add missing documentation for supported query filters for the `GET /me/accounts` and `GET /me/cards` endpoints.

Also adjust whitespace and punctuation in these pages, and add a note about the possibility of there being multiple cards per currency.