### PR TITLE
Fix usage of markdown inside HTML blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Uphold API Reference
+
 This repository contains the source files of the Uphold API documentation which can be viewed at [https://uphold.com/en/developer/api/documentation](https://uphold.com/en/developer/api/documentation).
 
 # Contributing
+
 All submissions are welcome. To submit a change, fork this repo, commit your changes, and send us a pull request.

--- a/_accounts.md
+++ b/_accounts.md
@@ -61,7 +61,9 @@ Retrieves a list of accounts for the current user.
 
 `GET https://api.uphold.com/v0/me/accounts`
 
-<aside class="notice">Requires the `accounts:read` scope for Uphold Connect applications.</aside>
+<aside class="notice">
+  Requires the <code>accounts:read</code> scope for Uphold Connect applications.
+</aside>
 
 You can filter the list of returned accounts using query string parameters.
 Supported filters are `status:` and `type:`, with either a single value or a comma-separated list.
@@ -98,8 +100,12 @@ Retrieves the details about a specific account.
 
 `GET https://api.uphold.com/v0/me/accounts/:id`
 
-<aside class="notice">Requires the `accounts:read` scope for Uphold Connect applications.</aside>
-<aside class="notice">The account id must be owned by the user performing the API call.</aside>
+<aside class="notice">
+  Requires the <code>accounts:read</code> scope for Uphold Connect applications.
+</aside>
+<aside class="notice">
+  The account id must be owned by the user performing the API call.
+</aside>
 
 ### Response
 

--- a/_applications.md
+++ b/_applications.md
@@ -3,6 +3,7 @@
 ## Registering an application
 
 Developers will need to [register their application](https://support.uphold.com/hc/en-us/articles/217210266) before getting started. A registered application will be assigned a unique _Client Id_ and _Client Secret_.
+
 <aside class="notice">
   <strong>Security Notice</strong>: Your <i>Client Secret</i> should never be shared, must be kept secret at all times and should only be used from your server-side application.
 </aside>

--- a/_applications.md
+++ b/_applications.md
@@ -1,11 +1,14 @@
 # Applications
+
 ## Registering an application
+
 Developers will need to [register their application](https://support.uphold.com/hc/en-us/articles/217210266) before getting started. A registered application will be assigned a unique _Client Id_ and _Client Secret_.
 <aside class="notice">
   <strong>Security Notice</strong>: Your <i>Client Secret</i> should never be shared, must be kept secret at all times and should only be used from your server-side application.
 </aside>
 
 ## Considerations
+
 - For security reasons, your application **must** be secured with a valid _SSL_ certificate issued by a known Certificate Authority.
 - Likewise, the provided _Redirect URL_ when registering the application must be a valid static subresource. Notice that this property cannot be dynamically reconfigured during authorization requests for security reasons.
 - The _Redirect URL_ can also be a valid URI with a non-http/https protocol which is useful for mobile and desktop applications, for example: `my-app://uphold/connect`.
@@ -15,6 +18,7 @@ Developers will need to [register their application](https://support.uphold.com/
 - Standard [rate limits](#rate-limits) apply to all issued access tokens.
 
 ## Permissions
+
 When requesting authorization from a user the application must specify the level of access needed. These _scopes_ are displayed to the user on the authorization form and currently the user cannot opt-out of individual scopes.
 
 The API supports the following _scopes_:
@@ -35,6 +39,7 @@ transactions:withdraw             | Can create a withdrawal [transaction](#trans
 user:read                         | Can view the [user](#user-object) and their information.
 
 ### Deprecated scopes
+
 The following _scopes_ are deprecated and will be removed in a future version of the API:
 
 Scope              | Description
@@ -48,6 +53,7 @@ transactions:write | Can create a [transaction](#transaction-object) from any or
 </aside>
 
 ## Resources
+
 We prefer that you use these image resources when connecting your applications to Uphold.
 
 <img alt="Connect" src="images/buttons/green_bg/connect.png" srcset="images/buttons/green_bg/connect.png 1x, images/buttons/green_bg/connect@2x.png 2x"><br> [small (129x40)](images/buttons/green_bg/connect.png), [large (258x80)](images/buttons/green_bg/connect@2x.png), [vector (SVG)](images/buttons/green_bg/connect.svg)

--- a/_authentication.md
+++ b/_authentication.md
@@ -214,8 +214,12 @@ Parameter   | Required | Description
 ----------- | -------- | -----------------------------------------
 description | yes      | A human-readable description of this PAT.
 
-<aside class="notice">Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.</aside>
-<aside class="notice">Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.</aside>
+<aside class="notice">
+  Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.
+</aside>
+<aside class="notice">
+  Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.
+</aside>
 
 ### Revoking a PAT
 

--- a/_authentication.md
+++ b/_authentication.md
@@ -1,12 +1,15 @@
 # Authentication
+
 Uphold is an OAuth 2.0 compliant service.
 
 Partners looking to integrate with our API must [register an application](#registering-an-application). Applications that implement a user-facing web interface, to provide custom functionality for multiple Uphold users, should use the [Web Application Flow](#web-application-flow). Applications that implement a backend interface for a corporate partner (and therefore represent an Uphold user themselves) should use the [Client Credentials Flow](#client-credentials-flow).
 
 ## Web Application Flow
+
 Ideal for web applications that wish to retrieve information about a user's Uphold account or take actions on their behalf.
 
 ### Step 1 - Authorization
+
 The authenticating web application should redirect users to the following URL:
 
 `https://uphold.com/authorize/<client_id>`
@@ -24,6 +27,7 @@ scope     | yes      | Permissions to request from the user.
 state     | yes      | An unguessable, cryptographically secure random string used to protect against cross-site request forgery attacks.
 
 ### Step 2 - Requesting a Token
+
 > Exchanging the `code` for a `token`:
 
 ```bash
@@ -71,6 +75,7 @@ grant_type    | yes      | Must be set to *'authorization_code'*.
 </aside>
 
 ### Step 3 - Using the Access Token
+
 > Request using the 'Authorization' header:
 
 ```bash
@@ -89,11 +94,13 @@ Once you have obtained an access token you may call any protected API method on 
 </aside>
 
 ## Client Credentials Flow
+
 Ideal for backend integrations that do not require access to other Uphold user accounts.
 
 For **business usage only** you may choose to use client credentials authentication. This requires manual approval from Uphold.
 
 ### Creating a Token
+
 > To create a client credentials token, execute the following command (make sure the application is set to use client credentials and not authorization code):
 
 ```bash
@@ -121,6 +128,7 @@ grant_type    | yes      | Must be set to *'client_credentials'*.
 </aside>
 
 ### Using the Token
+
 > Request using the 'Authorization header':
 
 ```bash
@@ -139,11 +147,13 @@ Once you have obtained a client credentials token you may call any protected API
 </aside>
 
 ## Personal Access Tokens (PAT)
+
 Ideal for scripts, automated tools and command-line programs which remain under your control.
 
 For **personal usage only** you may choose to use a PAT. This token establishes who you are, provides full access to your user account and bypasses Two Factor Authentication, if enabled. For this reason it should be treated just like your email/password combination, i.e. remain secret and never shared with third parties. PATs can be issued and revoked individually.
 
 ### Listing PATs
+
 > To list active Personal Access Tokens, execute the following command:
 
 ```bash
@@ -171,6 +181,7 @@ To list Personal Access Tokens you may use the following endpoint:
 `GET https://api.uphold.com/v0/me/tokens`
 
 ### Creating a PAT
+
 > To create a Personal Access Token, execute the following command:
 
 ```bash
@@ -207,6 +218,7 @@ description | yes      | A human-readable description of this PAT.
 <aside class="notice">Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.</aside>
 
 ### Revoking a PAT
+
 > To revoke a Personal Access Token, execute the following command:
 
 ```bash
@@ -226,6 +238,7 @@ Parameter | Required | Description
 token     | yes      | The PAT you wish to revoke.
 
 ### Using a PAT
+
 > Example of using a personal access token to make requests to our API:
 
 ```bash
@@ -238,6 +251,7 @@ A PAT may be used for authenticating a request via the OAuth scheme.
 The `<token>` should be set as the `accessToken` received during creation.
 
 ## Basic Authentication
+
 > Simple request using email and password:
 
 ```bash

--- a/_cards.md
+++ b/_cards.md
@@ -77,7 +77,9 @@ Retrieves a list of cards for the current user.
 
 `GET https://api.uphold.com/v0/me/cards`
 
-<aside class="notice">Requires the <code>cards:read</code> scope for Uphold Connect applications.</aside>
+<aside class="notice">
+  Requires the <code>cards:read</code> scope for Uphold Connect applications.
+</aside>
 
 You can filter the list of returned cards using query string parameters.
 Supported filters are `currency:` (which accepts a comma-separated list of currencies) and `settings.starred:` (which accepts `true` or `false`).
@@ -128,9 +130,11 @@ Retrieves the details about a specific card.
 
 `GET https://api.uphold.com/v0/me/cards/:id`
 
-<aside class="notice">Requires the <code>cards:read</code> scope for Uphold Connect applications.</aside>
-
-<aside class="notice"><code>:id</code> can either be the card ID or its bitcoin address and it must be owned by the user making the call.
+<aside class="notice">
+  Requires the <code>cards:read</code> scope for Uphold Connect applications.
+</aside>
+<aside class="notice">
+  <code>:id</code> can either be the card ID or its bitcoin address and it must be owned by the user making the call.
 </aside>
 
 ### Response
@@ -151,7 +155,9 @@ curl https://api.uphold.com/v0/me/cards \
 
 `POST https://api.uphold.com/v0/me/cards`
 
-<aside class="notice">Requires the <code>cards:write</code> scope for Uphold Connect applications.</aside>
+<aside class="notice">
+  Requires the <code>cards:write</code> scope for Uphold Connect applications.
+</aside>
 
 Parameter | Description
 --------- | ----------------------------------------------------------------------------------------------------
@@ -176,7 +182,9 @@ curl https://api.uphold.com/v0/me/cards/37e002a7-8508-4268-a18c-7335a6ddf24b \
 
 `PATCH https://api.uphold.com/v0/me/cards/:id`
 
-<aside class="notice">Requires the <code>cards:write</code> scope for Uphold Connect applications.</aside>
+<aside class="notice">
+  Requires the <code>cards:write</code> scope for Uphold Connect applications.
+</aside>
 
 Parameter | Description
 --------- | -----------------------------------------------------------------
@@ -208,7 +216,9 @@ curl https://api.uphold.com/v0/me/cards/024e51fc-5513-4d82-882c-9b22024280cc/add
 
 Generate an address for a card.
 
-<aside class="notice">For the network `xrp-ledger` the response also returns the `tag` property, which is the corresponding `Destination Tag`.</aside>
+<aside class="notice">
+  For the network <code>xrp-ledger</code> the response also returns the <code>tag</code> property, which is the corresponding <code>Destination Tag</code>.
+</aside>
 
 > For an XRP Ledger address, the following JSON is returned:
 
@@ -224,7 +234,9 @@ Generate an address for a card.
 
 `POST https://api.uphold.com/v0/me/cards/:id/addresses`
 
-<aside class="notice">Requires the <code>cards:write</code> scope for Uphold Connect applications.</aside>
+<aside class="notice">
+  Requires the <code>cards:write</code> scope for Uphold Connect applications.
+</aside>
 
 Parameter | Description
 --------- | ----------------------------------------------------------------------------------------------
@@ -271,13 +283,17 @@ curl https://api.uphold.com/v0/me/cards/37e002a7-8508-4268-a18c-7335a6ddf24b/add
 
 Retrieves a list of addresses for a specific card.
 
-<aside class="notice">The property `tag` is defined only to allow the XRP Ledger network to identify the card's `Destination Tag`.</aside>
+<aside class="notice">
+  The property <code>tag</code> is defined only to allow the XRP Ledger network to identify the card's <code>Destination Tag</code>.
+</aside>
 
 ### Request
 
 `GET https://api.uphold.com/v0/me/cards/:id/addresses`
 
-<aside class="notice">Requires the <code>cards:read</code> scope for Uphold Connect applications.</aside>
+<aside class="notice">
+  Requires the <code>cards:read</code> scope for Uphold Connect applications.
+</aside>
 
 ### Response
 

--- a/_contacts.md
+++ b/_contacts.md
@@ -1,4 +1,5 @@
 # Contacts
+
 ## List Contacts
 
 ```bash
@@ -33,10 +34,12 @@ curl https://api.uphold.com/v0/me/contacts \
 ```
 
 ### Request
+
 `GET https://api.uphold.com/v0/me/contacts`
 <aside class="notice">Requires the `contacts:read` scope for Uphold Connect applications.</aside>
 
 ### Response
+
 Returns an array of contact objects associated with the current user.
 
 ## Get Contact
@@ -63,10 +66,12 @@ curl https://api.uphold.com/v0/me/contacts/9fae84eb-712d-4b6a-9b2c-764bdde4c079 
 ```
 
 ### Request
+
 `GET https://api.uphold.com/v0/me/contacts/:id`
 <aside class="notice">Requires the `contacts:read` scope for Uphold Connect applications.</aside>
 
 ### Response
+
 Returns an associative array containing the details of the designated contact.
 
 ## Create Contact
@@ -80,6 +85,7 @@ curl https://api.uphold.com/v0/me/contacts \
 ```
 
 ### Request
+
 `POST https://api.uphold.com/v0/me/contacts`
 <aside class="notice">Requires the `contacts:write` scope for Uphold Connect applications.</aside>
 
@@ -92,4 +98,5 @@ emails    | List of email addresses.
 addresses | List of bitcoin addresses.
 
 ### Response
+
 A fully formed [Contact Object](#contact-object)

--- a/_contacts.md
+++ b/_contacts.md
@@ -36,7 +36,10 @@ curl https://api.uphold.com/v0/me/contacts \
 ### Request
 
 `GET https://api.uphold.com/v0/me/contacts`
-<aside class="notice">Requires the `contacts:read` scope for Uphold Connect applications.</aside>
+
+<aside class="notice">
+  Requires the <code>contacts:read</code> scope for Uphold Connect applications.
+</aside>
 
 ### Response
 
@@ -68,7 +71,10 @@ curl https://api.uphold.com/v0/me/contacts/9fae84eb-712d-4b6a-9b2c-764bdde4c079 
 ### Request
 
 `GET https://api.uphold.com/v0/me/contacts/:id`
-<aside class="notice">Requires the `contacts:read` scope for Uphold Connect applications.</aside>
+
+<aside class="notice">
+  Requires the <code>contacts:read</code> scope for Uphold Connect applications.
+</aside>
 
 ### Response
 
@@ -87,7 +93,10 @@ curl https://api.uphold.com/v0/me/contacts \
 ### Request
 
 `POST https://api.uphold.com/v0/me/contacts`
-<aside class="notice">Requires the `contacts:write` scope for Uphold Connect applications.</aside>
+
+<aside class="notice">
+  Requires the <code>contacts:write</code> scope for Uphold Connect applications.
+</aside>
 
 Parameter | Description
 --------- | --------------------------------------

--- a/_entities.md
+++ b/_entities.md
@@ -1,4 +1,5 @@
 # Entities
+
 ## Account Object
 > An example account encoded in JSON looks like this:
 
@@ -27,6 +28,7 @@ status   | The current status of the account. Possible values are: `ok`, `failed
 type     | The type of the account. Possible values are: `card`, `sepa`.
 
 ## Authentication Method Object
+
 > An example authentication method encoded in JSON looks like this:
 
 ```json
@@ -50,6 +52,7 @@ verified     | A boolean signalling whether or not the authentication method has
 verifiedAt   | The date and time of verification of the authentication method.
 
 ## Card Object
+
 > An example card encoded in JSON looks like this:
 
 ```json
@@ -89,6 +92,7 @@ settings          | Contains the card's current `position` and whether the card 
 normalized        | Contains the normalized `available` and `balance` values in the currency set by the user in the settings.
 
 ## Contact Object
+
 > An example contact encoded in JSON looks like this:
 
 ```json
@@ -118,6 +122,7 @@ lastName  | The last name of this contact provided by the user.
 name      | The display name of the contact created by joining the first and last names.
 
 ## Currency Pair Object
+
 > An example currency pair encoded in JSON looks like this:
 
 ```json
@@ -141,6 +146,7 @@ currency | The currency that is used in the `ask` and `bid` prices.
 pair     | The currency pair AB represents moving from A to B.
 
 ## Transaction Object
+
 > An example transaction encoded in JSON looks like this:
 
 ```json
@@ -257,6 +263,7 @@ destination  | The recipient of the funds. See [Destination](#destination).
 </aside>
 
 ### Denomination
+
 The actual value being transacted is denominated in a certain currency, as expressed by the `denomination` field with the following properties:
 
 Property | Description
@@ -271,6 +278,7 @@ rate     | The quoted rate for converting between the denominated currency and t
 </aside>
 
 ### Fees
+
 The `fees` property contains an array of fees that were applied to the transaction. Each object in the array contains the following properties:
 
 Property   | Description
@@ -286,6 +294,7 @@ type       | The type of fee. Can be one of: `deposit`, `exchange`, `network` or
 </aside>
 
 ### Parameters
+
 The `params` property associated with a transaction records additional meta data relating to the respective transaction. It contains the following properties:
 
 Property | Description
@@ -299,6 +308,7 @@ ttl      | The time this quote is good for, in milliseconds.
 type     | The type of the transaction. Possible values are `deposit`, `transfer` and `withdrawal`.
 
 ### Normalized
+
 The `normalized` property contains the normalized amount and commission values in USD:
 
 Property   | Description
@@ -311,6 +321,7 @@ rate       | The exchange rate for this pair.
 target     | Can be `origin` or `destination` and determines where the fee was applied.
 
 ### Origin
+
 The origin has properties regarding how the transaction affects the origin of the funds:
 
 Property    | Description
@@ -333,6 +344,7 @@ type        | The type of endpoint. Possible values are 'card' and 'external'.
 </aside>
 
 ### Destination
+
 The destination of a transaction has its own set of properties describing how the destination is affected, which include:
 
 Property    | Description
@@ -350,6 +362,7 @@ rate        | The rate for conversion between origin and destination, as express
 type        | The type of endpoint. Possible values are 'email', 'card' and 'external'.
 
 ## User Object
+
 > An example user encoded in JSON looks like this:
 
 ```json
@@ -565,6 +578,7 @@ memberAt | The date when the user has become a verified member.
 - **otp.vmc.enabled** - This will prompt the user to input an OTP token when using VMCs.
 
 ### User Status
+
 We communicate a number of different user states through our API. At a high-level users can be in one of four states:
 
 - **pending** - This state is present while the user is creating an account.

--- a/_entities.md
+++ b/_entities.md
@@ -236,8 +236,11 @@ pair     | The currency pair AB represents moving from A to B.
 ```
 
 Transactions record the movement of value into, within and out of the Uphold network. Transactions have the following properties:
+
 <aside class="notice">
-  There are two views of a transaction: public and private. The private view of information only privy to those who were a party to the transaction. Public views suppress and hide any private or personally identifiable information in order for Uphold to protect user privacy.
+  There are two views of a transaction: public and private.
+  The private view of information only privy to those who were a party to the transaction.
+  Public views suppress and hide any private or personally identifiable information in order for Uphold to protect user privacy.
 </aside>
 
 Property     | Description
@@ -274,7 +277,7 @@ pair     | The currency pair representing the denominated currency and the curre
 rate     | The quoted rate for converting between the denominated currency and the currency at `origin`.
 
 <aside class="notice">
-  If the `denomination` and `origin` are the same currency, the `rate` will be '1.00'.
+  If the <code>denomination</code> and <code>origin</code> are the same currency, the <code>rate</code> will be '1.00'.
 </aside>
 
 ### Fees
@@ -561,8 +564,10 @@ type        | The type of endpoint. Possible values are 'email', 'card' and 'ext
 ```
 
 The `user` object contains most of the information we have on record relating to the currently logged in user.
+
 <aside class="notice">
-  <strong>Privacy Notice</strong>: Users are only permitted to access information about themselves. Our API does not allow accessing information about other users.
+  <strong>Privacy Notice</strong>: Users are only permitted to access information about themselves.
+  Our API does not allow accessing information about other users.
 </aside>
 
 Property | Description

--- a/_errors.md
+++ b/_errors.md
@@ -1,4 +1,5 @@
 # Errors
+
 Uphold API uses the following error codes:
 
 Code | Meaning

--- a/_introduction.md
+++ b/_introduction.md
@@ -1,7 +1,9 @@
 # Introduction
+
 Welcome to the Uphold API, we're glad to have you! Provided here is all the documentation you need to help you create custom and revolutionary new services powered by the Uphold Platform. With your ingenuity, together we can serve the needs of individuals and organizations across the globe and change the financial services ecosystem forever.
 
 ## Client Libraries
+
 The follow libraries are available:
 
 - [Android SDK](https://github.com/uphold/uphold-sdk-android)
@@ -14,6 +16,7 @@ The follow libraries are available:
 We are actively looking for developers to contribute Uphold client libraries for a variety of platforms and languages. If you have written a library, please share a link to the github repository with us at [developer@uphold.com](mailto:developer@uphold.com?subject=I want to contribute code) so that we can promote it here, and collaborate with you on its further development.
 
 ## API Changes
+
 You can be notified of the latest changes by _watching_ our official [documentation repository](https://github.com/uphold/docs/) on GitHub and by following our [developer blog](https://uphold.com/en/developer/blog).
 
 The official changelog is currently on [GitHub](https://github.com/uphold/docs/releases).

--- a/_pagination.md
+++ b/_pagination.md
@@ -1,7 +1,9 @@
 # Pagination
+
 Collection endpoints with large dataset supports [Range Pagination Headers](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html), using the `Range` and `Content-Range` entity-headers.
 
 ## Request
+
 You can provide the `Range` header in your request to specify how many items you want to retrieve.
 The maximum number of items per page is 50. That is also the default value if you leave it unspecified.
 
@@ -15,6 +17,7 @@ curl https://api.uphold.com/v0/me/transactions \
 ```
 
 ## Response
+
 The endpoints that support pagination will return a `Content-Range` header.
 For instance, if you make a request with the `Range: items=0-4` header, the response will contain the header `Content-Range: 0-4/*`, where `*` will be the total number of items available for listing.
 

--- a/_ratelimits.md
+++ b/_ratelimits.md
@@ -1,4 +1,5 @@
 # Rate Limits
+
 The API applies rate limits based on the number of requests per a predefined interval (i.e. a time-window). We currently do not differentiate between authenticated and unauthenticated requests. The global rate limit takes into account the remote client IP only.
 
 We plan on changing this policy in the future to one that limits on an account-by-account basis. For now, please be advised that those operating from corporate networks may hit their limit faster given that everyone may present the same IP address to our network.
@@ -20,6 +21,7 @@ POST /users                               |         10 / 10-min window |        
 </aside>
 
 ## Response Headers
+
 The current rate limit in effect is explained via custom HTTP headers as described in the table below. Additionally, the standard HTTP `Retry-After` header field will be appended when the rate limit is exhausted and indicates, in delta-seconds, how long until the rate limit window is reset.
 
 Header               | Description

--- a/_support.md
+++ b/_support.md
@@ -1,4 +1,5 @@
 # Support
+
 Need help, or have a question? Contact <a href="mailto:developer@uphold.com?Subject=Help%20Me" target="_top">developer@uphold.com</a>.
 
 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/_tickers.md
+++ b/_tickers.md
@@ -1,4 +1,5 @@
 # Tickers
+
 Developers can query at any time the rates we utilize when exchanging one form of value for another. These are expressed in "currency pairs".
 
 ## Get Tickers for Currency
@@ -447,9 +448,11 @@ curl https://api.uphold.com/v0/ticker/USD
 This method allows developers to find all exchanges rates relative to a given currency.
 
 ### Request
+
 `GET https://api.uphold.com/v0/ticker/:currency`
 
 ### Response
+
 Returns an associative array containing the current rates Uphold has on record for the currency specified. If no currency is specified on the endpoint, USD currency pair will be returned by default.
 
 ## Get Tickers for Currency Pair
@@ -491,7 +494,9 @@ The order of the currencies in the pair affects the output.
 As is shown in the example, the endpoint will provide the exchange rate from the first currency to the second currency.
 
 ### Request
+
 `GET https://api.uphold.com/v0/ticker/:pair`
 
 ### Response
+
 Returns an object containing the current rate Uphold has on record for the specified currency pair.

--- a/_totp.md
+++ b/_totp.md
@@ -69,8 +69,12 @@ curl https://api.uphold.com/v0/me/authentication_methods/totp \
 
 `POST https://api.uphold.com/v0/me/authentication_methods/totp`
 
-<aside class="notice">Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.</aside>
-<aside class="notice">Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.</aside>
+<aside class="notice">
+  Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.
+</aside>
+<aside class="notice">
+  Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.
+</aside>
 
 
 ### Response
@@ -126,9 +130,15 @@ curl https://api.uphold.com/v0/me/authentication_methods/3f8f8264-2f5e-4b2b-8333
 
 `DELETE https://api.uphold.com/v0/me/authentication_methods/3f8f8264-2f5e-4b2b-8333-473715ab039a`
 
-<aside class="notice">Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.</aside>
-<aside class="notice">Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.</aside>
-<aside class="notice">You cannot delete all of a user's authentication methods as trying to delete the last verified method of a user will return an error.</aside>
+<aside class="notice">
+  Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.
+</aside>
+<aside class="notice">
+  Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.
+</aside>
+<aside class="notice">
+  You cannot delete all of a user's authentication methods as trying to delete the last verified method of a user will return an error.
+</aside>
 
 ### Response
 

--- a/_transactions.md
+++ b/_transactions.md
@@ -1,5 +1,7 @@
 # Transactions
+
 ## Create &amp; Commit a Transaction
+
 > Step 1: Create the Transaction
 
 ```bash
@@ -109,6 +111,7 @@ curl https://api.uphold.com/v0/me/cards/a6d35fcd-xxxx-9c9d1dda6d57/transactions/
 > Returns a [Transaction Object](#transaction-object).
 
 ### Step 1: Create Transaction
+
 In step one, one prepares the transaction by specifying:
 
 - The _currency_ to denominate the transaction by.
@@ -130,27 +133,33 @@ Upon preparing a transaction, a [Transaction Object](#transaction-object) will b
 <aside class="notice">If the deposit origin is a `CARD` account ID and the query string parameter `?commit=true` is set, you need to send the `securityCode` in the request body.</aside>
 
 ### Request
+
 `POST https://api.uphold.com/v0/me/cards/:card/transactions`
 <aside class="notice">Requires any of the following scopes: `transactions:deposit`, `transactions:transfer:application`, `transactions:transfer:others`, `transactions:transfer:self` or `transactions:withdraw` for Uphold Connect applications. If creating with the query string parameter `?commit=true`, the scope has to match the type of transaction being committed.</aside>
 
 ### Response
+
 Returns a [Transaction Object](#transaction-object).
 <aside class="notice">If the deposit origin is a `CARD` account ID and the query string parameter `?commit=true` is set, the transaction's `params` will include a `redirect` field with information of a redirect URI to be followed to complete the credit card deposit.</aside>
 
 ### Step 2: Commit Transaction
+
 Once a transaction has been created and a quote secured, commit the transaction using the previously returned `id`. An optional parameter `message` can also be sent which will overwrite the value currently stored in the transaction.
 
 ### Request
+
 `POST https://api.uphold.com/v0/me/cards/:card/transactions/:id/commit`
 <aside class="notice">Requires any of the following scopes, based on the type of transaction being committed: `transactions:deposit`, `transactions:transfer:application`, `transactions:transfer:others`, `transactions:transfer:self` or `transactions:withdraw` for Uphold Connect applications.</aside>
 <aside class="notice">If the deposit origin is a `CARD` account ID, you need to send the `securityCode` in the request body.</aside>
 <aside class="notice">If the user has recently changed their password, they may be in a cool-down period where outbound transactions are not allowed, for security reasons. This results in a 400 HTTP error with code <code>password_reset_restriction</code>. Your application must be prepared to handle this failure scenario.</aside>
 
 ### Response
+
 Returns a [Transaction Object](#transaction-object).
 <aside class="notice">If the deposit origin is a `CARD` account ID, the transaction's `params` will include a `redirect` field with information of a redirect URI to be followed to complete the credit card deposit.</aside>
 
 ## Confirm a Credit Card Deposit
+
 > Example of `redirect` found in `transaction.params` for credit card deposit responses:
 
 ```bash
@@ -199,10 +208,12 @@ url        | The URL of the 3DSecure confirmation request.
 <aside class="notice">This feature requires approval from Uphold's compliance team. Partners using this feature must not store the provided `securityCode`, in compliance with PCI DSS standards.</aside>
 
 ### Request
+
 `POST <transaction.params.redirect.url>`
 <aside class="notice">Requires passing in the request body the parameters found in `transaction.params.redirect.parameters` in the format `name=value`.</aside>
 
 ### Response
+
 A webpage for 3DSecure confirmation for the user to interact with.
 
 ## Cancel a Transaction
@@ -218,10 +229,12 @@ curl https://api.uphold.com/v0/me/cards/a6d35fcd-xxxx-9c9d1dda6d57/transactions/
 Cancels a transaction that has not yet been redeemed.
 
 ### Request
+
 `POST https://api.uphold.com/v0/me/cards/:card/transactions/:id/cancel`
 <aside class="notice">Requires the `transactions:transfer:others` scope for Uphold Connect applications.</aside>
 
 ### Response
+
 Returns a [Transaction Object](#transaction-object).
 <aside class="notice">Only transactions with status `waiting` can be cancelled.</aside>
 
@@ -238,10 +251,12 @@ curl https://api.uphold.com/v0/me/cards/a6d35fcd-xxxx-9c9d1dda6d57/transactions/
 Triggers a reminder for a transaction that hasn't been redeemed yet.
 
 ### Request
+
 `POST https://api.uphold.com/v0/me/cards/:card/transactions/:id/resend`
 <aside class="notice">Requires the `transactions:transfer:others` scope for Uphold Connect applications.</aside>
 
 ### Response
+
 Returns a [Transaction Object](#transaction-object).
 <aside class="notice">Only transactions with status `waiting` can be resent.</aside>
 
@@ -344,12 +359,14 @@ curl https://api.uphold.com/v0/me/transactions \
 Requests a list of transactions associated with the current user.
 
 ### Request
+
 `GET https://api.uphold.com/v0/me/transactions`
 <aside class="notice">Requires the `transactions:read` scope for Uphold Connect applications.</aside>
 
 This endpoint supports [Pagination](#pagination).
 
 ### Response
+
 Returns an array of [Transaction Objects](#transaction-object).
 
 ## List Card Transactions
@@ -451,12 +468,14 @@ curl https://api.uphold.com/v0/me/cards/48ce2ac5-c038-4426-b2f8-a2bdbcc93053/tra
 Requests a list of transactions associated with a specific card.
 
 ### Request
+
 `GET https://api.uphold.com/v0/me/cards/:card/transactions`
 <aside class="notice">Requires the `transactions:read` scope for Uphold Connect applications.</aside>
 
 This endpoint supports [Pagination](#pagination).
 
 ### Response
+
 Returns an array of [Transaction Objects](#transaction-object).
 
 ## Get All Transactions (Public)
@@ -607,11 +626,13 @@ Requests the public view of all transactions in the reserve.
 To access this endpoint, an API key is required.
 
 ### Request
+
 `GET https://api.uphold.com/v0/reserve/transactions`
 
 This endpoint supports [Pagination](#pagination).
 
 ### Response
+
 Returns an array of [Transaction Objects](#transaction-object).
 <aside class="notice">Be advised that this method has the potential to return a great deal of data.</aside>
 
@@ -671,8 +692,10 @@ See also: [Transparency: Reservechain](#the-reservechain)
 Requests the public view of a specific transaction.
 
 ### Request
+
 `GET https://api.uphold.com/v0/reserve/transactions/:id`
 
 ### Response
+
 Returns a [Transaction Object](#transaction-object).
 <aside class="notice">Note that you will only receive the list of committed transactions.</aside>

--- a/_transactions.md
+++ b/_transactions.md
@@ -128,19 +128,34 @@ withdrawal | Uphold card id                     | _ACH_, _SEPA_ or _Bitcoin_ add
 transfer   | Uphold card id                     | An email address, an application id or an Uphold card id
 
 Upon preparing a transaction, a [Transaction Object](#transaction-object) will be returned with a newly-generated `id`.
-<aside class="notice">You may only send value from addresses that you own.</aside>
-<aside class="notice">Adding the query string parameter `?commit=true` to this request will create and commit the transaction in a single step.</aside>
-<aside class="notice">If the deposit origin is a `CARD` account ID and the query string parameter `?commit=true` is set, you need to send the `securityCode` in the request body.</aside>
+
+<aside class="notice">
+  You may only send value from addresses that you own.
+</aside>
+<aside class="notice">
+  Adding the query string parameter <code>?commit=true</code> to this request will create and commit the transaction in a single step.
+</aside>
+<aside class="notice">
+  If the deposit origin is a <code>CARD</code> account ID and the query string parameter <code>?commit=true</code> is set, you need to send the <code>securityCode</code> in the request body.
+</aside>
 
 ### Request
 
 `POST https://api.uphold.com/v0/me/cards/:card/transactions`
-<aside class="notice">Requires any of the following scopes: `transactions:deposit`, `transactions:transfer:application`, `transactions:transfer:others`, `transactions:transfer:self` or `transactions:withdraw` for Uphold Connect applications. If creating with the query string parameter `?commit=true`, the scope has to match the type of transaction being committed.</aside>
+
+<aside class="notice">
+  Requires any of the following scopes: <code>transactions:deposit</code>, <code>transactions:transfer:application</code>, <code>transactions:transfer:others</code>, <code>transactions:transfer:self</code> or <code>transactions:withdraw</code> for Uphold Connect applications.
+  If creating with the query string parameter <code>?commit=true</code>, the scope has to match the type of transaction being committed.
+</aside>
 
 ### Response
 
 Returns a [Transaction Object](#transaction-object).
-<aside class="notice">If the deposit origin is a `CARD` account ID and the query string parameter `?commit=true` is set, the transaction's `params` will include a `redirect` field with information of a redirect URI to be followed to complete the credit card deposit.</aside>
+
+<aside class="notice">
+  If the deposit origin is a <code>CARD</code> account ID and the query string parameter <code>?commit=true</code> is set,
+  the transaction's <code>params</code> will include a <code>redirect</code> field with information of a redirect URI to be followed to complete the credit card deposit.
+</aside>
 
 ### Step 2: Commit Transaction
 
@@ -149,14 +164,28 @@ Once a transaction has been created and a quote secured, commit the transaction 
 ### Request
 
 `POST https://api.uphold.com/v0/me/cards/:card/transactions/:id/commit`
-<aside class="notice">Requires any of the following scopes, based on the type of transaction being committed: `transactions:deposit`, `transactions:transfer:application`, `transactions:transfer:others`, `transactions:transfer:self` or `transactions:withdraw` for Uphold Connect applications.</aside>
-<aside class="notice">If the deposit origin is a `CARD` account ID, you need to send the `securityCode` in the request body.</aside>
-<aside class="notice">If the user has recently changed their password, they may be in a cool-down period where outbound transactions are not allowed, for security reasons. This results in a 400 HTTP error with code <code>password_reset_restriction</code>. Your application must be prepared to handle this failure scenario.</aside>
+
+<aside class="notice">
+  Requires any of the following scopes, based on the type of transaction being committed:
+  <code>transactions:deposit</code>, <code>transactions:transfer:application</code>, <code>transactions:transfer:others</code>, <code>transactions:transfer:self</code> or <code>transactions:withdraw</code>
+  for Uphold Connect applications.
+</aside>
+<aside class="notice">
+  If the deposit origin is a <code>CARD</code> account ID, you need to send the <code>securityCode</code> in the request body.
+</aside>
+<aside class="notice">
+  If the user has recently changed their password, they may be in a cool-down period where outbound transactions are not allowed, for security reasons.
+  This results in a 400 HTTP error with code <code>password_reset_restriction</code>.
+  Your application must be prepared to handle this failure scenario.
+</aside>
 
 ### Response
 
 Returns a [Transaction Object](#transaction-object).
-<aside class="notice">If the deposit origin is a `CARD` account ID, the transaction's `params` will include a `redirect` field with information of a redirect URI to be followed to complete the credit card deposit.</aside>
+
+<aside class="notice">
+  If the deposit origin is a <code>CARD</code> account ID, the transaction's <code>params</code> will include a <code>redirect</code> field with information of a redirect URI to be followed to complete the credit card deposit.
+</aside>
 
 ## Confirm a Credit Card Deposit
 
@@ -205,12 +234,18 @@ Property   | Description
 parameters | List of objects with `name` and `value` properties to send to the 3DSecure confirmation request body.
 url        | The URL of the 3DSecure confirmation request.
 
-<aside class="notice">This feature requires approval from Uphold's compliance team. Partners using this feature must not store the provided `securityCode`, in compliance with PCI DSS standards.</aside>
+<aside class="notice">
+  This feature requires approval from Uphold's compliance team.
+  Partners using this feature must not store the provided <code>securityCode</code>, in compliance with PCI DSS standards.
+</aside>
 
 ### Request
 
 `POST <transaction.params.redirect.url>`
-<aside class="notice">Requires passing in the request body the parameters found in `transaction.params.redirect.parameters` in the format `name=value`.</aside>
+
+<aside class="notice">
+  Requires passing in the request body the parameters found in <code>transaction.params.redirect.parameters</code> in the format <code>name=value</code>.
+</aside>
 
 ### Response
 
@@ -231,12 +266,18 @@ Cancels a transaction that has not yet been redeemed.
 ### Request
 
 `POST https://api.uphold.com/v0/me/cards/:card/transactions/:id/cancel`
-<aside class="notice">Requires the `transactions:transfer:others` scope for Uphold Connect applications.</aside>
+
+<aside class="notice">
+  Requires the <code>transactions:transfer:others</code> scope for Uphold Connect applications.
+</aside>
 
 ### Response
 
 Returns a [Transaction Object](#transaction-object).
-<aside class="notice">Only transactions with status `waiting` can be cancelled.</aside>
+
+<aside class="notice">
+  Only transactions with status <code>waiting</code> can be cancelled.
+</aside>
 
 ## Resend a Transaction
 
@@ -253,12 +294,18 @@ Triggers a reminder for a transaction that hasn't been redeemed yet.
 ### Request
 
 `POST https://api.uphold.com/v0/me/cards/:card/transactions/:id/resend`
-<aside class="notice">Requires the `transactions:transfer:others` scope for Uphold Connect applications.</aside>
+
+<aside class="notice">
+  Requires the <code>transactions:transfer:others</code> scope for Uphold Connect applications.
+</aside>
 
 ### Response
 
 Returns a [Transaction Object](#transaction-object).
-<aside class="notice">Only transactions with status `waiting` can be resent.</aside>
+
+<aside class="notice">
+  Only transactions with status <code>waiting</code> can be resent.
+</aside>
 
 ## List User Transactions
 
@@ -361,7 +408,10 @@ Requests a list of transactions associated with the current user.
 ### Request
 
 `GET https://api.uphold.com/v0/me/transactions`
-<aside class="notice">Requires the `transactions:read` scope for Uphold Connect applications.</aside>
+
+<aside class="notice">
+  Requires the <code>transactions:read</code> scope for Uphold Connect applications.
+</aside>
 
 This endpoint supports [Pagination](#pagination).
 
@@ -470,7 +520,10 @@ Requests a list of transactions associated with a specific card.
 ### Request
 
 `GET https://api.uphold.com/v0/me/cards/:card/transactions`
-<aside class="notice">Requires the `transactions:read` scope for Uphold Connect applications.</aside>
+
+<aside class="notice">
+  Requires the <code>transactions:read</code> scope for Uphold Connect applications.
+</aside>
 
 This endpoint supports [Pagination](#pagination).
 
@@ -634,7 +687,10 @@ This endpoint supports [Pagination](#pagination).
 ### Response
 
 Returns an array of [Transaction Objects](#transaction-object).
-<aside class="notice">Be advised that this method has the potential to return a great deal of data.</aside>
+
+<aside class="notice">
+  Be advised that this method has the potential to return a great deal of data.
+</aside>
 
 ## Get Transaction (Public)
 
@@ -698,4 +754,7 @@ Requests the public view of a specific transaction.
 ### Response
 
 Returns a [Transaction Object](#transaction-object).
-<aside class="notice">Note that you will only receive the list of committed transactions.</aside>
+
+<aside class="notice">
+  Note that you will only receive the list of committed transactions.
+</aside>

--- a/_transparency.md
+++ b/_transparency.md
@@ -1,4 +1,5 @@
 # Transparency
+
 The following section outlines a system for how Uphold will provide the transparency our members require in order to ascertain the solvency of the reserve we operate to protect the value entrusted to us by our Members.
 
 We will provide our members with access to two different resources. The first is the Uphold Ledger, or "Reserveledger" as we call it. The Reserveledger is a real-time listing of all the company's assets and liabilities. Each entry in the ledger can reference one or more transactions that a user can inquire about and obtain the details of via the second key resource: the Reservechain.
@@ -267,9 +268,11 @@ currency    | The currency we are computing the current holding in.
 rate        | The rate we used when computing the holding to the corresponding currency.
 
 ### Request
+
 `GET https://api.uphold.com/v0/reserve/statistics`
 
 ## The Reserveledger
+
 Our ledger provides a detailed record of the obligations (a.k.a. "liabilities") flowing into our network via our members, and the resulting changes we as a company make to the assets in our reserve to secure the value of those obligations.
 
 The ledger is made up of "entries", each of which contains information about the change to an asset, a liability, or both, and references the related transactions that affected the change whenever possible.
@@ -289,6 +292,7 @@ This endpoint supports [Pagination](#pagination).
 To access this endpoint, an API key is required.
 
 ### Deposits
+
 The following entry shows how a deposit of 0.5 bitcoin by a user would be encoded on the Reserveledger. Every deposit results in two entries in the ledger. The first records the acquisition of a liability, and the second the genesis of an asset. Specifically, it shows the creation of 0.5 bitcoin as an obligation to the user, plus the acquisition of 0.5 bitcoin as an asset.
 <pre class="inline"><code>{
   "type": "liability",
@@ -318,6 +322,7 @@ The following entry shows how a deposit of 0.5 bitcoin by a user would be encode
 </code></pre>
 
 ### Transfer of Value
+
 The entry below shows how a user transferring 1.3 bitcoin to a "dollar card", effectively exchanging bitcoin for dollars, would be encoded on the ledger. In this entry, two liabilities are affected. The first is a loss of 1.3 BTC as an obligation, and the second is a gain of $507.51 USD as an obligation. Which makes sense: when a user transfers the bitcoin to their dollar card, Uphold no longer owes them that bitcoin. Instead, Uphold owes them the $507.51 they exchanged for that bitcoin.
 <pre class="inline"><code>{
   "type": "liability",
@@ -352,6 +357,7 @@ This transfer of value affects our liabilities immediately and in real-time, and
 The examples above are nearly identical from one another due to the simplicity of the use case it elucidates. Consider however that when operating normally it is likely that a series of changes to our liabilities will be aggregated and accounted for in a single change to our assets in order to restore balance to the reserve.
 
 ### Withdrawal of Bitcoin
+
 When value is removed from the Reserve, two entries are added. One accounting for the change in assets, and the other for the change in liabilities. The following entry shows how a user transmitting some bitcoin to an external network/wallet would be encoded on the ledger. It shows the removal of a liability of bitcoin to the user, and the subsequent removal of bitcoin as an asset.
 <pre class="inline"><code>{
   "type": "asset",
@@ -381,6 +387,7 @@ When value is removed from the Reserve, two entries are added. One accounting fo
 </code></pre>
 
 ### Reallocation of Assets
+
 Uphold may decide to secure the value of its Reserve by holding value in asset classes which may or may not correlate to how our liabilities are denominated among our members. For example, Uphold may wish to convert $1,000,000 in cash into a security of equal value. These changes to the Reserve do not relate to any specific transaction, but need to be accounted for nonetheless. What follows is how we could encode shifting 1M dollars into a US Treasury Bill. Take note that we can optionally include additional data relating to the asset class.
 <pre class="inline"><code>{
   "type": "asset",
@@ -407,6 +414,7 @@ Uphold may decide to secure the value of its Reserve by holding value in asset c
 </aside>
 
 ## The Reservechain
+
 Uphold's Reservechain is a record of all of the transactions made by its Members that move value through the network. It is a "chain" in that any value moved in a transaction can be easily traced back to it's origin.
 
 At a high level, each transaction in the Reservechain contains the following key pieces of information:
@@ -422,12 +430,15 @@ At a high level, each transaction in the Reservechain contains the following key
 </aside>
 
 ### Traceability
+
 Just like a block chain, the Reservechain is both completely transparent, and **traceable**. For a transaction to be traceable, the value encapsulated by the transaction must reference all the places within the chain where that value is drawn from. This is done by providing a list of transaction IDs, and the value drawn from each. By following these transactions you walk backwards down different paths of the Reservechain until you ultimately find a genesis point for all value accounted for in the transaction.
 
 ### Security and Privacy
+
 All transactions are made public, but specific details about the transaction may be withheld from parties who were not a party to said transaction. To control this we would require developers to authenticate prior to retrieving privileged information relating to a transaction.
 
 ### Deposits
+
 A deposit relates to two things: the adding of value into the Reservechain from the outside, and the creation of a new obligation to a user.
 
 Given that this is a point in the chain at which there is a genesis of value, there are no subsequent transactions within the Reservechain to link backwards to. However, we will provide a link to the external authority documenting the source of the value whenever possible.
@@ -468,6 +479,7 @@ Given that this is a point in the chain at which there is a genesis of value, th
 </code></pre>
 
 ### Withdrawals
+
 Withdrawal documents the flow of assets out of the system. The destination of the transaction would refer as completely as it can to any external sources that the Uphold transaction can be correlated against/with.
 
 Withdrawals also account for value leaving the Reservechain, and is thus a terminus point with regards to traceability.
@@ -512,6 +524,7 @@ Withdrawals also account for value leaving the Reservechain, and is thus a termi
 </code></pre>
 
 ### Transfers
+
 A transfer documents movement of value within our network, either between two parties or two denominations, or both.
 <pre class="inline"><code>{
   "id": "1571fbef-d34e-447c-9b6e-4ad775953082",
@@ -556,6 +569,7 @@ A transfer documents movement of value within our network, either between two pa
 </code></pre>
 
 ## Privacy
+
 The Reservechain is a public resource, and is 100% anonymous. **At no point does the Reservechain expose any personally identifiable information**, or any information that could be directly tied to an identity with our network.
 
 We may disclose personally identifiable information to those who were a party to a transaction by way of the protected [List User Transactions](#list-user-transactions) and [List Card Transactions](#list-card-transactions) endpoints.

--- a/_users.md
+++ b/_users.md
@@ -80,12 +80,18 @@ curl "https://api.uphold.com/v0/me" \
 ### Request
 
 `GET https://api.uphold.com/v0/me`
-<aside class="notice">Requires the `user:read` scope for Uphold Connect applications.</aside>
+
+<aside class="notice">
+  Requires the <code>user:read</code> scope for Uphold Connect applications.
+</aside>
 
 ### Response
 
 Returns the details associated the current user.
-<aside class="notice">Be advised that this method has the potential to return a great deal of data.</aside>
+
+<aside class="notice">
+  Be advised that this method has the potential to return a great deal of data.
+</aside>
 
 ### Cards
 

--- a/_users.md
+++ b/_users.md
@@ -1,4 +1,5 @@
 # Users
+
 ## Get User
 
 ```bash
@@ -77,10 +78,12 @@ curl "https://api.uphold.com/v0/me" \
 ```
 
 ### Request
+
 `GET https://api.uphold.com/v0/me`
 <aside class="notice">Requires the `user:read` scope for Uphold Connect applications.</aside>
 
 ### Response
+
 Returns the details associated the current user.
 <aside class="notice">Be advised that this method has the potential to return a great deal of data.</aside>
 
@@ -109,7 +112,9 @@ curl "https://api.uphold.com/v0/me/phones" \
 ```
 
 ### Request
+
 `GET https://api.uphold.com/v0/me/phones`
 
 ### Response
+
 Returns an array of all the phone numbers associated with the current user.

--- a/_webhooks.md
+++ b/_webhooks.md
@@ -1,4 +1,5 @@
 # Webhooks
+
 For **business usage only** you may choose to use webhooks to get updates in real time instead of having to poll the API. This requires manual approval from Uphold.
 
 A webhooks integration requires the following details:


### PR DESCRIPTION
Interaction between markdown and HTML blocks is currently complex and has many edge cases, especially related to whitespace and blank lines. See the examples in the spec: https://spec.commonmark.org/0.29/#html-blocks

This was the cause of some unprocessed formatting (mostly code fenced with backticks) inside some of the `<aside>` blocks, as can be seen in the `_cards.md`, `_entities.md` and `_transactions.md` pages.

The unreliability of markdown inside the `<aside>` is actually [documented in the slate wiki](https://github.com/slatedocs/slate/wiki/Markdown-Syntax#notes-and-warnings), and has been the cause of various issues: https://github.com/slatedocs/slate/issues/183, https://github.com/slatedocs/slate/issues/236, https://github.com/slatedocs/slate/issues/270.

As a solution (and standardizing on a practice that was already present in various pages of this project) all formatting inside `<aside>` blocks is converted to HTML.

This way the content becomes robust to such flaky interactions, and the existing cases are fixed.