### PR TITLE
Improve references to HTTP errors

### DIFF
--- a/_authentication.md
+++ b/_authentication.md
@@ -267,5 +267,5 @@ curl https://api.uphold.com/v0/me \
 
 You can use Basic Authentication by providing your email and password combination.
 
-If OTP (One-Time Password, also known as Two-Factor Authentication) is required, then you will get an HTTP 401 (Unauthorized) response, along with the HTTP header `OTP-Token: Required` and/or `OTP-Method-Id: Required`.
+If OTP (One-Time Password, also known as Two-Factor Authentication) is required, then you will get a [401 HTTP error](#errors), along with the HTTP headers `OTP-Token: Required` and `OTP-Method-Id: Required`.
 In which case, execute the command above again, this time passing your OTP verification code and method id as a headers, like so: `OTP-Token: <OTP-Token>` and `OTP-Method-Id: <OTP-Method-Id>`.

--- a/_errors.md
+++ b/_errors.md
@@ -3,14 +3,14 @@
 Uphold API uses the following error codes:
 
 Code | Meaning
----- | ---------------------------------------------------------------------------------------------------
-400  | Bad Request -- Validation failed.
-401  | Unauthorized -- Bad credentials.
-403  | Forbidden -- Access forbidden.
-404  | Not Found -- Object not found.
-409  | Conflict -- Entity already exists.
-412  | Precondition Failed
-416  | Requested Range Not Satisfiable
-429  | Too Many Requests -- Rate limit exceeded.
-500  | Internal Server Error -- Something went wrong in our server.
-503  | Service Unavailable -- We're temporarily offline for maintenance. Please try again in a little bit.
+---- | --------------------------------------------------------------------------
+400  | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)
+401  | [Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)
+403  | [Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)
+404  | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)
+409  | [Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)
+412  | [Precondition Failed](https://tools.ietf.org/html/rfc7232#section-4.2)
+416  | [Range Not Satisfiable](https://tools.ietf.org/html/rfc7233#section-4.4)
+429  | [Too Many Requests](http://tools.ietf.org/html/rfc6585#section-4)
+500  | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)
+503  | [Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)

--- a/_pagination.md
+++ b/_pagination.md
@@ -21,4 +21,4 @@ curl https://api.uphold.com/v0/me/transactions \
 The endpoints that support pagination will return a `Content-Range` header.
 For instance, if you make a request with the `Range: items=0-4` header, the response will contain the header `Content-Range: 0-4/*`, where `*` will be the total number of items available for listing.
 
-If the `Range` header is malformed or if the range cannot be satisfied, you will receive a 412 error or a 416 error, respectively.
+If the `Range` header is malformed or if the range cannot be satisfied, you will receive a [412 HTTP error](#errors) or a [416 HTTP error](#errors), respectively.

--- a/_ratelimits.md
+++ b/_ratelimits.md
@@ -45,7 +45,7 @@ Rate-Limit-Remaining: 499
 Rate-Limit-Reset: 1422288284
 ```
 
-When the API limit is reached, a status code of [429 Too Many Requests](http://tools.ietf.org/html/rfc6585#section-4) is returned with the aforementioned `Retry-After` header:
+When the API limit is reached, a [429 HTTP error](#errors) is returned with the aforementioned `Retry-After` header:
 
 > Example response for a rate limited request:
 


### PR DESCRIPTION
Link all error references to the Errors page, and add external links in the Errors page for further details.