### PR TITLE
Document how to specify multiple filters for listing methods

### DIFF
--- a/_accounts.md
+++ b/_accounts.md
@@ -24,10 +24,10 @@ curl https://api.uphold.com/v0/me/accounts \
   -H "Authorization: Bearer <token>"
 ```
 
-> This list can be filtered. For example, to list only accounts of the `sepa` or `card` types, you can specify the types in the query string, like so:
+> Example of filtering the list to show only accounts of the `sepa` or `card` types, and in the `ok` status:
 
 ```bash
-curl https://api.uphold.com/v0/me/accounts?q=type:sepa,card
+curl 'https://api.uphold.com/v0/me/accounts?q=type:sepa,card%20status:ok'
   -H "Authorization: Bearer <token>"
 ```
 
@@ -68,6 +68,7 @@ Retrieves a list of accounts for the current user.
 You can filter the list of returned accounts using query string parameters.
 Supported filters are `status:` and `type:`, with either a single value or a comma-separated list.
 For a list of valid values for these parameters, refer to the [Account Object](#account-object) documentation.
+Multiple filters can be used together, separated with a space.
 See the code to the right for an example.
 
 ### Response

--- a/_cards.md
+++ b/_cards.md
@@ -17,10 +17,10 @@ curl https://api.uphold.com/v0/me/cards \
   -H "Authorization: Bearer <token>"
 ```
 
-> This list can be filtered. For example, to list only cards denominated in BTC or EUR, you can specify the currencies in the query string, like so:
+> Example of filtering the list to show only starred cards denominated in BTC or EUR:
 
 ```bash
-curl https://api.uphold.com/v0/me/cards?q=currency:BTC,EUR
+curl 'https://api.uphold.com/v0/me/cards?q=currency:BTC,EUR%20settings.starred:true'
   -H "Authorization: Bearer <token>"
 ```
 
@@ -83,6 +83,7 @@ Retrieves a list of cards for the current user.
 
 You can filter the list of returned cards using query string parameters.
 Supported filters are `currency:` (which accepts a comma-separated list of currencies) and `settings.starred:` (which accepts `true` or `false`).
+Multiple filters can be used together, separated with a space.
 See the code to the right for an example.
 
 This endpoint supports [Pagination](#pagination).


### PR DESCRIPTION
Also quote URLs with query strings in curl commands, to avoid shell expansion.

Follow-up of #187.