### PR TITLE
Document working auth methods for TOTP and PATs

### DIFF
--- a/_authentication.md
+++ b/_authentication.md
@@ -187,10 +187,10 @@ To list Personal Access Tokens you may use the following endpoint:
 ```bash
 curl https://api.uphold.com/v0/me/tokens \
   -X POST \
-  -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -H "OTP-Method-Id: <Method-Id>" \
   -H "OTP-Token: <OTP-Token>" \
+  -u <email>:<password> \
   -d '{ "description": "My command line script" }'
 ```
 

--- a/_authentication.md
+++ b/_authentication.md
@@ -215,10 +215,7 @@ Parameter   | Required | Description
 description | yes      | A human-readable description of this PAT.
 
 <aside class="notice">
-  Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.
-</aside>
-<aside class="notice">
-  Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.
+  Requires the <code>OTP-Method-Id</code> header with the id of a verified authentication method that belongs to the user, and the <code>OTP-Token</code> header with a valid TOTP token associated to that authentication method.
 </aside>
 
 ### Revoking a PAT

--- a/_totp.md
+++ b/_totp.md
@@ -70,12 +70,8 @@ curl https://api.uphold.com/v0/me/authentication_methods/totp \
 `POST https://api.uphold.com/v0/me/authentication_methods/totp`
 
 <aside class="notice">
-  Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.
+  Requires the <code>OTP-Method-Id</code> header with the id of a verified authentication method that belongs to the user, and the <code>OTP-Token</code> header with a valid TOTP token associated to that authentication method.
 </aside>
-<aside class="notice">
-  Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.
-</aside>
-
 
 ### Response
 
@@ -107,7 +103,6 @@ curl https://api.uphold.com/v0/me/authentication_methods/3f8f8264-2f5e-4b2b-8333
 ### Request
 
 `POST https://api.uphold.com/v0/me/authentication_methods/:id/verify`
-
 
 ### Response
 

--- a/_totp.md
+++ b/_totp.md
@@ -7,7 +7,7 @@ The following section documents how the Authentication Methods API works to prov
 
 ```bash
 curl https://api.uphold.com/v0/me/authentication_methods \
-  -H "Authorization: Bearer <token>"
+  -u <email>:<password>
 ```
 
 > The above command returns the following JSON:


### PR DESCRIPTION
Restore working instructions for calling the `/me/authentication_methods` and the `/me/tokens` endpoints, for getting the OTP method IDs, and creating new PATs, respectively. Partially reverts #161, to sync the docs with changes made to the platform since then. Fixes #184.