### PR TITLE
Update list of valid networks for card addresses

### DIFF
--- a/_cards.md
+++ b/_cards.md
@@ -240,8 +240,8 @@ Generate an address for a card.
 </aside>
 
 Parameter | Description
---------- | ----------------------------------------------------------------------------------------------
-network   | The address network. Possible values are: `bitcoin`, `ethereum` or `litecoin`.
+--------- | -----------------------------------------------------------------------------------------------------------------------------------------------------
+network   | The address network. Possible values are: `bitcoin`, `bitcoin-cash`, `bitcoin-gold`, `dash`, `ethereum`, `interledger`, `litecoin`, and `xrp-ledger`.
 
 ### Response
 


### PR DESCRIPTION
The list of crypto networks available for creating card addresses was outdated.
This PR expands the list so it includes all the currently supported cryptocurrency networks for card addresses.
