### PR TITLE
Link the term "currency pair" to the relevant section

### DIFF
--- a/_countries.md
+++ b/_countries.md
@@ -145,7 +145,7 @@ currency   | The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code of the 
 method     | The type of payment method. One of "[ach](https://en.wikipedia.org/wiki/ACH_Network)", "[card](https://en.wikipedia.org/wiki/Credit_card)", or "[sepa](https://en.wikipedia.org/wiki/Single_Euro_Payments_Area)".
 
 <aside class="notice">
-  Each method+currency pair is represented as a separate entry in this list. For example, if both USD and EUR are supported for the <code>card</code> method, the list will contain two entries, one with the USD-card pair, and one with the EUR-card pair.
+  Each method+currency pair is represented as a separate entry in this list. For example, if both <code>USD</code> and <code>EUR</code> are supported for the <code>card</code> method, the list will contain two entries, one with the <code>USD</code>-<code>card</code> pair, and one with the <code>EUR</code>-<code>card</code> pair.
 </aside>
 
 ## Get Country Subdivisions

--- a/_entities.md
+++ b/_entities.md
@@ -273,7 +273,7 @@ Property | Description
 -------- | ---------------------------------------------------------------------------------------------
 amount   | The amount to be transacted.
 currency | The currency for said amount.
-pair     | The currency pair representing the denominated currency and the currency at `origin`.
+pair     | The [currency pair](#currency-pair-object) representing the denominated currency and the currency at `origin`.
 rate     | The quoted rate for converting between the denominated currency and the currency at `origin`.
 
 <aside class="notice">
@@ -304,7 +304,7 @@ Property | Description
 -------- | -----------------------------------------------------------------------------------------------
 currency | The currency in which the total commission is expressed.
 margin   | Uphold's commission expressed in percentage.
-pair     | The currency pair associated with any exchange that took place, if any.
+pair     | The [currency pair](#currency-pair-object) associated with any exchange that took place, if any.
 progress | In case a transaction is coming in from the outside, how many confirmations have been received.
 rate     | The exchange rate of the transaction.
 ttl      | The time this quote is good for, in milliseconds.
@@ -320,7 +320,7 @@ amount     | The amount to be transacted.
 commission | The total commission taken on this transaction, either at origin or at destination.
 currency   | The currency in which the amount and commission are expressed. The value is always `USD`.
 fee        | The normalized fee amount.
-rate       | The exchange rate for this pair.
+rate       | The exchange rate for this [currency pair](#currency-pair-object).
 target     | Can be `origin` or `destination` and determines where the fee was applied.
 
 ### Origin

--- a/_tickers.md
+++ b/_tickers.md
@@ -1,6 +1,6 @@
 # Tickers
 
-Developers can query at any time the rates we utilize when exchanging one form of value for another. These are expressed in "currency pairs".
+Developers can query at any time the rates we utilize when exchanging one form of value for another. These are expressed in [currency pairs](#currency-pair-object).
 
 ## Get Tickers for Currency
 


### PR DESCRIPTION
Link all (relevant) mentions of the term "currency pair" to the subsection under the Entities that describes them.
Also clarify other occurrences of the word "pair".

Ideally we should have an system that automatically links instances of a defined term to its definition (like Rust docs does), but for now, manually adding the links is already a net positive.
