### PR TITLE
Document ability to filter the list of assets

### DIFF
--- a/_currencies.md
+++ b/_currencies.md
@@ -87,6 +87,12 @@ curl https://api.uphold.com/v0/assets \
   -H "Authorization: Bearer <token>"
 ```
 
+> Example of filtering the list to show only assets of specific `type`s:
+
+```bash
+curl https://api.uphold.com/v0/assets?q=type:cryptocurrency,fiat,equity
+```
+
 Get the list of supported currencies and other financial assets, with details as described by the table below:
 
 Property   | Description
@@ -102,6 +108,9 @@ If the request is unauthenticated, the full list of assets supported by Uphold i
 Authenticated requests, on the other hand, will filter the output,
 returning only the assets available for the current user,
 which can depend on factors such as their country and state of residency.
+
+The list of assets returned can also be filtered by `type` using a query string parameter,
+as shown in the example to the side.
 
 Please note that this endpoint is [paginated](#pagination), due to the large number of supported assets (hundreds),
 so multiple requests may be required to get the complete list.

--- a/_currencies.md
+++ b/_currencies.md
@@ -1,7 +1,7 @@
 # Currencies
 
 Uphold [supports](https://uphold.com/en/transparency) multiple financial assets,
- including traditional currencies, cryptocurrencies, stablecoins, precious metals, U.S. equities, and more.
+including traditional currencies, cryptocurrencies, stablecoins, precious metals, U.S. equities, and more.
 
 <aside class="notice">
   For brevity and convenience, we may refer to any such asset simply as "currency" throughout the API documentation.
@@ -96,12 +96,15 @@ formatting | Specification for user-facing display, including number formatting 
 name       | Full name of the asset, e.g. "Euro", "Basic Attention Token", or "0x".
 status     | Current trading status. See [below](#asset-status) for more details.
 symbol     | A short and well-known representation of the asset, if one exists — e.g. "$", "₿", or "Kč".
-type       | Type of asset. Possible values are `commodity`, `equity`, `cryptocurrency`, `fiat`, `stablecoin` and `utility_token`.
+type       | Type of asset. Possible values are `commodity`, `cryptocurrency`, `equity`, `fiat`, `stablecoin` and `utility_token`.
 
 If the request is unauthenticated, the full list of assets supported by Uphold is returned.
-Authenticated requests, on the other hand, will filter the output, returning only the assets available for the current user, which can depend on factors such as their country and state of residency.
+Authenticated requests, on the other hand, will filter the output,
+returning only the assets available for the current user,
+which can depend on factors such as their country and state of residency.
 
-Please note that this endpoint is [paginated](#pagination), due to the large number of supported assets (hundreds), so multiple requests may be required to get the complete list.
+Please note that this endpoint is [paginated](#pagination), due to the large number of supported assets (hundreds),
+so multiple requests may be required to get the complete list.
 
 ### Asset status
 


### PR DESCRIPTION
Note: Since we're working on this document, a separate commit was added to wrap long lines in it (following the [semantic linefeeds](https://rhodesmill.org/brandon/2012/one-sentence-per-line/) pattern), and to sort the list of asset types alphabetically.
