### PR TITLE
Various wording, spelling and punctuation improvements

### DIFF
--- a/_applications.md
+++ b/_applications.md
@@ -2,7 +2,8 @@
 
 ## Registering an application
 
-Developers will need to [register their application](https://support.uphold.com/hc/en-us/articles/217210266) before getting started. A registered application will be assigned a unique _Client Id_ and _Client Secret_.
+Developers will need to [register their application](https://support.uphold.com/hc/en-us/articles/217210266) before getting started.
+A registered application will be assigned a unique _Client Id_ and _Client Secret_.
 
 <aside class="notice">
   <strong>Security Notice</strong>: Your <i>Client Secret</i> should never be shared, must be kept secret at all times and should only be used from your server-side application.
@@ -20,7 +21,8 @@ Developers will need to [register their application](https://support.uphold.com/
 
 ## Permissions
 
-When requesting authorization from a user the application must specify the level of access needed. These _scopes_ are displayed to the user on the authorization form and currently the user cannot opt-out of individual scopes.
+When requesting authorization from a user the application must specify the level of access needed.
+These _scopes_ are displayed to the user on the authorization form and currently the user cannot opt-out of individual scopes.
 
 The API supports the following _scopes_:
 

--- a/_authentication.md
+++ b/_authentication.md
@@ -2,7 +2,9 @@
 
 Uphold is an OAuth 2.0 compliant service.
 
-Partners looking to integrate with our API must [register an application](#registering-an-application). Applications that implement a user-facing web interface, to provide custom functionality for multiple Uphold users, should use the [Web Application Flow](#web-application-flow). Applications that implement a backend interface for a corporate partner (and therefore represent an Uphold user themselves) should use the [Client Credentials Flow](#client-credentials-flow).
+Partners looking to integrate with our API must [register an application](#registering-an-application).
+Applications that implement a user-facing web interface, to provide custom functionality for multiple Uphold users, should use the [Web Application Flow](#web-application-flow).
+Applications that implement a backend interface for a corporate partner (and therefore represent an Uphold user themselves) should use the [Client Credentials Flow](#client-credentials-flow).
 
 ## Web Application Flow
 
@@ -97,7 +99,8 @@ Once you have obtained an access token you may call any protected API method on 
 
 Ideal for backend integrations that do not require access to other Uphold user accounts.
 
-For **business usage only** you may choose to use client credentials authentication. This requires manual approval from Uphold.
+For **business usage only** you may choose to use client credentials authentication.
+This requires manual approval from Uphold.
 
 ### Creating a Token
 
@@ -141,8 +144,8 @@ Once you have obtained a client credentials token you may call any protected API
 `Authorization: Bearer <token>`
 
 <aside class="notice">
-  <strong>Security Notice</strong>: No other method of authentication is supported. For security reasons only the "Authorization" header will be processed.
-
+  <strong>Security Notice</strong>: No other method of authentication is supported.
+  For security reasons only the "Authorization" header will be processed.
   This prevents attackers from stealing tokens from the user's browser history, logs, referer headers and other unsecure locations when credentials are sent via query URLs.
 </aside>
 
@@ -150,7 +153,10 @@ Once you have obtained a client credentials token you may call any protected API
 
 Ideal for scripts, automated tools and command-line programs which remain under your control.
 
-For **personal usage only** you may choose to use a PAT. This token establishes who you are, provides full access to your user account and bypasses Two Factor Authentication, if enabled. For this reason it should be treated just like your email/password combination, i.e. remain secret and never shared with third parties. PATs can be issued and revoked individually.
+For **personal usage only** you may choose to use a PAT.
+This token establishes who you are, provides full access to your user account and bypasses Two Factor Authentication, if enabled.
+For this reason it should be treated just like your email/password combination, i.e. remain secret and never shared with third parties.
+PATs can be issued and revoked individually.
 
 ### Listing PATs
 

--- a/_authentication.md
+++ b/_authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Uphold is an OAuth 2.0 compliant service.
+Uphold is an [OAuth 2.0](https://oauth.net/2/)-compliant service.
 
 Partners looking to integrate with our API must [register an application](#registering-an-application).
 Applications that implement a user-facing web interface, to provide custom functionality for multiple Uphold users, should use the [Web Application Flow](#web-application-flow).
@@ -20,12 +20,18 @@ Or for sandbox applications:
 
 `https://sandbox.uphold.com/authorize/<client_id>`
 
+> Example of an authorization request URL:
+
+```
+https://uphold.com/authorize/<client_id>?state=<state_string>&scope=accounts:read%20cards:read
+```
+
 Supported query parameters:
 
 Parameter | Required | Description
---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------
-intention | no       | Unauthenticated users will be redirected to the `login` page, this behavior can be changed by sending `signup` as the `intention` value.
-scope     | yes      | Permissions to request from the user.
+--------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------
+intention | no       | By default, unauthenticated users will be redirected to the `login` page. This behavior can be changed by sending `signup` as the `intention` value.
+scope     | yes      | Permissions to request from the user. Multiple scopes [should be](https://tools.ietf.org/html/rfc6749#section-3.3) separated by spaces.
 state     | yes      | An unguessable, cryptographically secure random string used to protect against cross-site request forgery attacks.
 
 ### Step 2 - Requesting a Token
@@ -92,7 +98,7 @@ Once you have obtained an access token you may call any protected API method on 
 <aside class="notice">
   <strong>Security Notice</strong>: No other method of authentication is supported. For security reasons only the "Authorization" header will be processed.
 
-  This prevents attackers from stealing tokens from the user's browser history, logs, referer headers and other unsecure locations when credentials are sent via query URLs.
+  This prevents attackers from stealing tokens from the user's browser history, logs, referrer headers and other insecure locations when credentials are sent via query URLs.
 </aside>
 
 ## Client Credentials Flow
@@ -100,7 +106,7 @@ Once you have obtained an access token you may call any protected API method on 
 Ideal for backend integrations that do not require access to other Uphold user accounts.
 
 For **business usage only** you may choose to use client credentials authentication.
-This requires manual approval from Uphold.
+This requires [manual approval](#support) from Uphold.
 
 ### Creating a Token
 
@@ -146,7 +152,7 @@ Once you have obtained a client credentials token you may call any protected API
 <aside class="notice">
   <strong>Security Notice</strong>: No other method of authentication is supported.
   For security reasons only the "Authorization" header will be processed.
-  This prevents attackers from stealing tokens from the user's browser history, logs, referer headers and other unsecure locations when credentials are sent via query URLs.
+  This prevents attackers from stealing tokens from the user's browser history, logs, referrer headers and other insecure locations when credentials are sent via query URLs.
 </aside>
 
 ## Personal Access Tokens (PAT)
@@ -270,5 +276,5 @@ curl https://api.uphold.com/v0/me \
 
 You can use Basic Authentication by providing your email and password combination.
 
-If OTP (One-Time Password, also known as Two-Factor Authentication) is required, then you will get a [401 HTTP error](#errors), along with the HTTP headers `OTP-Token: Required` and `OTP-Method-Id: Required`.
-In which case, execute the command above again, this time passing your OTP verification code and method id as a headers, like so: `OTP-Token: <OTP-Token>` and `OTP-Method-Id: <OTP-Method-Id>`.
+If OTP (One-Time Password, also known as Two-Factor Authentication) is required, then you will get a [401 HTTP error](#errors), along with the HTTP header `OTP-Token: Required` and/or `OTP-Method-Id: Required`.
+In which case, execute the command above again, this time passing your OTP verification code and method id as headers, like so: `OTP-Token: <OTP-Token>` and `OTP-Method-Id: <OTP-Method-Id>`.

--- a/_currencies.md
+++ b/_currencies.md
@@ -1,13 +1,18 @@
 # Currencies
 
-Uphold [supports](https://uphold.com/en/transparency) multiple financial assets, including traditional currencies, cryptocurrencies, stablecoins, precious metals, U.S. equities, and more.
+Uphold [supports](https://uphold.com/en/transparency) multiple financial assets,
+ including traditional currencies, cryptocurrencies, stablecoins, precious metals, U.S. equities, and more.
 
 <aside class="notice">
   For brevity and convenience, we may refer to any such asset simply as "currency" throughout the API documentation.
   In cases that only apply to specific classes of assets, we will clarify accordingly.
 </aside>
 
-In Uphold's API, various endpoints include currencies in their input or output. We represent all such currencies by an abbreviation **code** of variable length, typically containing uppercase letters (for example, a currency's [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code, an equity's [ticker symbol](https://en.wikipedia.org/wiki/Ticker_symbol), or other similar well-known representation).
+In Uphold's API, various endpoints include currencies in their input or output.
+We represent all such currencies by an abbreviation **code** of variable length, typically containing uppercase letters
+(for example, a currency's [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code,
+an equity's [ticker symbol](https://en.wikipedia.org/wiki/Ticker_symbol),
+or other similar well-known representation).
 
 ## List Supported Assets
 

--- a/_entities.md
+++ b/_entities.md
@@ -134,7 +134,7 @@ name      | The display name of the contact created by joining the first and las
 }
 ```
 
-A currency pair is the combination of two currencies, encoded as two currency codes, e.g. USD, GBP, EUR, concatenated together to represent the current status of converting the first currency into the second.
+A currency pair is the combination of two currencies, encoded as two [currency codes](#currencies) concatenated together to represent the current status of converting the first currency into the second.
 For example, the currency pair "BTCUSD" represents moving from bitcoin to US dollars.
 
 Each currency pair has four properties:

--- a/_entities.md
+++ b/_entities.md
@@ -134,7 +134,8 @@ name      | The display name of the contact created by joining the first and las
 }
 ```
 
-A currency pair is the combination of two currencies, encoded as two currency codes, e.g. USD, GBP, EUR, concatenated together to represent the current status of converting the first currency into the second. For example, the currency pair "BTCUSD" represents moving from bitcoin to US dollars.
+A currency pair is the combination of two currencies, encoded as two currency codes, e.g. USD, GBP, EUR, concatenated together to represent the current status of converting the first currency into the second.
+For example, the currency pair "BTCUSD" represents moving from bitcoin to US dollars.
 
 Each currency pair has four properties:
 
@@ -265,7 +266,8 @@ verified            | A boolean indicating if this phone number has been verifie
 }
 ```
 
-Transactions record the movement of value into, within and out of the Uphold network. Transactions have the following properties:
+Transactions record the movement of value into, within and out of the Uphold network.
+Transactions have the following properties:
 
 <aside class="notice">
   There are two views of a transaction: public and private.
@@ -312,7 +314,8 @@ rate     | The quoted rate for converting between the denominated currency and t
 
 ### Fees
 
-The `fees` property contains an array of fees that were applied to the transaction. Each object in the array contains the following properties:
+The `fees` property contains an array of fees that were applied to the transaction.
+Each object in the array contains the following properties:
 
 Property   | Description
 ---------- | ---------------------------------------------------------------------------------
@@ -528,17 +531,22 @@ memberAt | The date when the user became a [verified member](https://support.uph
 
 ### User Status
 
-We communicate a number of different user statuses through our API. At a high-level users can be in one of four statuses:
+We communicate a number of different user statuses through our API.
+At a high-level users can be in one of four statuses:
 
-- **pending** - This status applies to a user that is in the process of creating an account; it means the signup process is not yet finalized.
-- **restricted** - This status means the user is allowed to login to the application, deposit or receive money, and perform trades, but they are not permitted to withdraw nor send money to other users. This status exists to allow users to satisfy additional data requirements.
-- **blocked** - This status is present when a user has violated our terms of service. In this status users are unable to login or access the product.
+- **pending** - This status applies to a user that is in the process of creating an account;
+  it means the signup process is not yet finalized.
+- **restricted** - This status means the user is allowed to login to the application, deposit or receive money, and perform trades, but they are not permitted to withdraw nor send money to other users.
+  This status exists to allow users to satisfy additional data requirements.
+- **blocked** - This status is present when a user has violated our terms of service.
+  In this status users are unable to login or access the product.
 - **ok** - Everything is ay-ok.
 
 ### User Verifications
 
 The `verifications` field can help communicate the reasons for a given user status, or what's missing to complete the membership process.
-These verifications have permissible values and in some cases, an associated reason. Here is an overview of the verifications field:
+These verifications have permissible values and in some cases, an associated reason.
+Here is an overview of the verifications field:
 
 Flag      | Permissible Values               | Reason         | Description
 --------- | -------------------------------- | -------------- | --------------------------------------------------------------------------------------

--- a/_introduction.md
+++ b/_introduction.md
@@ -1,6 +1,8 @@
 # Introduction
 
-Welcome to the Uphold API — we're glad to have you! Here you can find all the documentation you need to help you create custom and revolutionary new services powered by the Uphold Platform. Together, with your ingenuity, we can serve the needs of individuals and organizations across the globe and change the financial services ecosystem forever.
+Welcome to the Uphold API — we're glad to have you!
+Here you can find all the documentation you need to help you create custom and revolutionary new services powered by the Uphold Platform.
+Together, with your ingenuity, we can serve the needs of individuals and organizations across the globe and change the financial services ecosystem forever.
 
 ## API code samples
 

--- a/_pagination.md
+++ b/_pagination.md
@@ -5,7 +5,8 @@ Collection endpoints with large dataset supports [Range Pagination Headers](http
 ## Request
 
 You can provide the `Range` header in your request to specify how many items you want to retrieve.
-The maximum number of items per page is 50. That is also the default value if you leave it unspecified.
+The maximum number of items per page is 50.
+That is also the default value if you leave it unspecified.
 
 > For example, here's how you'd fetch the five most recent transactions associated with the current user.
 > Note that the items are indexed from zero:

--- a/_ratelimits.md
+++ b/_ratelimits.md
@@ -1,10 +1,17 @@
 # Rate Limits
 
-The API applies rate limits based on the number of requests per a predefined interval (i.e. a time-window). We currently do not differentiate between authenticated and unauthenticated requests. The global rate limit takes into account the remote client IP only.
+The API applies rate limits based on the number of requests per a predefined interval (i.e. a time-window).
+We currently do not differentiate between authenticated and unauthenticated requests.
+The global rate limit takes into account the remote client IP only.
 
-We plan on changing this policy in the future to one that limits on an account-by-account basis. For now, please be advised that those operating from corporate networks may hit their limit faster given that everyone may present the same IP address to our network.
+We plan on changing this policy in the future to one that limits on an account-by-account basis.
+For now, please be advised that those operating from corporate networks may hit their limit faster,
+given that everyone may present the same IP address to our network.
 
-Some endpoints have stricter rules as it relates to rate limits. These endpoints may additionally take into consideration the user's account or email address. For example, there can be 10 requests per 10 minute time period per IP to the `/password/forgot` endpoint; but multiple IPs can only make 3 requests per 5 minute time period per user account (e.g. `foo@bar.com`).
+Some endpoints have stricter rules as it relates to rate limits.
+These endpoints may additionally take into consideration the user's account or email address.
+For example, there can be 10 requests per 10 minute time period per IP to the `/password/forgot` endpoint;
+but multiple IPs can only make 3 requests per 5 minute time period per user account (e.g. `foo@bar.com`).
 
 The following table indicates the current rate limits:
 
@@ -22,7 +29,9 @@ POST /users                               |         10 / 10-min window |        
 
 ## Response Headers
 
-The current rate limit in effect is explained via custom HTTP headers as described in the table below. Additionally, the standard HTTP `Retry-After` header field will be appended when the rate limit is exhausted and indicates, in delta-seconds, how long until the rate limit window is reset.
+The current rate limit in effect is explained via custom HTTP headers as described in the table below.
+Additionally, the standard HTTP `Retry-After` header field will be appended when the rate limit is exhausted,
+and indicates, in delta-seconds, how long until the rate limit window is reset.
 
 Header               | Description
 -------------------- | ----------------------------------------------------------------------------------------------------------------------

--- a/_tickers.md
+++ b/_tickers.md
@@ -1,6 +1,6 @@
 # Tickers
 
-Developers can query at any time the rates we utilize when exchanging one form of value for another.
+At any time, you can query the rates we utilize when exchanging one form of value for another.
 These are expressed in [currency pairs](#currency-pair-object).
 
 ## Get Tickers for Currency
@@ -446,7 +446,7 @@ curl https://api.uphold.com/v0/ticker/USD
 }]
 ```
 
-This method allows developers to find all exchanges rates relative to a given currency.
+Lists all exchange rates relative to a given currency.
 
 ### Request
 
@@ -487,7 +487,7 @@ curl https://api.uphold.com/v0/ticker/EUR-USD
 }
 ```
 
-This method allows developers to find the exchange rate of a currency relative to any other currency.
+Retrieves the exchange rate of a currency relative to any other currency.
 
 <aside class="notice">
 The order of the currencies in the pair affects the output.

--- a/_tickers.md
+++ b/_tickers.md
@@ -1,6 +1,7 @@
 # Tickers
 
-Developers can query at any time the rates we utilize when exchanging one form of value for another. These are expressed in [currency pairs](#currency-pair-object).
+Developers can query at any time the rates we utilize when exchanging one form of value for another.
+These are expressed in [currency pairs](#currency-pair-object).
 
 ## Get Tickers for Currency
 
@@ -453,7 +454,8 @@ This method allows developers to find all exchanges rates relative to a given cu
 
 ### Response
 
-Returns an associative array containing the current rates Uphold has on record for the currency specified. If no currency is specified on the endpoint, USD currency pair will be returned by default.
+Returns an associative array containing the current rates Uphold has on record for the currency specified.
+If no currency is specified on the endpoint, USD currency pair will be returned by default.
 
 ## Get Tickers for Currency Pair
 

--- a/_totp.md
+++ b/_totp.md
@@ -1,6 +1,7 @@
 # One-Time Password
 
-Uphold provides a TOTP (Time-Based One-Time Password) mechanism to secure user accounts. Adopting and adhering to this mechanism is recommended for safety reasons.
+Uphold provides a TOTP (Time-Based One-Time Password) mechanism to secure user accounts.
+Adopting and adhering to this mechanism is recommended for safety reasons.
 The following section documents how the Authentication Methods API works to provide support for this security mechanism.
 
 ## List Authentication Methods

--- a/_transactions.md
+++ b/_transactions.md
@@ -126,11 +126,11 @@ The first step is to prepare the transaction by specifying:
 
 The following table describes the types of transactions currently supported:
 
-Type       | Origin                             | Destination
----------- | ---------------------------------- | --------------------------------------------------------
-deposit    | _ACH_, _CARD_ or _SEPA_ account id | Uphold card id
-withdrawal | Uphold card id                     | _ACH_, _SEPA_ or _Bitcoin_ address
-transfer   | Uphold card id                     | An email address, an application id or an Uphold card id
+Type       | Origin                              | Destination
+---------- | ----------------------------------- | --------------------------------------------------------
+deposit    | ACH, credit card or SEPA account id | Uphold card id
+withdrawal | Uphold card id                      | ACH or SEPA account id, or cryptocurrency address
+transfer   | Uphold card id                      | Email address, Application id or Uphold card id
 
 Upon preparing a transaction, a [Transaction Object](#transaction-object) will be returned with a newly-generated `id`, and a status of `pending`.
 
@@ -777,7 +777,7 @@ This endpoint supports [Pagination](#pagination).
 Returns an array of [Transaction Objects](#transaction-object).
 
 <aside class="notice">
-  Be advised that this method has the potential to return a great deal of data.
+  Be advised that this method can potentially return a large amount of data.
 </aside>
 
 ## Get Transaction (Public)

--- a/_transparency.md
+++ b/_transparency.md
@@ -2,7 +2,10 @@
 
 The following section outlines a system for how Uphold will provide the transparency our members require in order to ascertain the solvency of the reserve we operate to protect the value entrusted to us by our Members.
 
-We will provide our members with access to two different resources. The first is the Uphold Ledger, or "Reserveledger" as we call it. The Reserveledger is a real-time listing of all the company's assets and liabilities. Each entry in the ledger can reference one or more transactions that a user can inquire about and obtain the details of via the second key resource: the Reservechain.
+We will provide our members with access to two different resources.
+The first is the Uphold Ledger, or "Reserveledger" as we call it.
+The Reserveledger is a real-time listing of all the company's assets and liabilities.
+Each entry in the ledger can reference one or more transactions that a user can inquire about and obtain the details of via the second key resource: the Reservechain.
 
 ## Reserve Status
 
@@ -250,7 +253,9 @@ curl https://api.uphold.com/v0/reserve/statistics
 }]
 ```
 
-To assist developers with tracking the overall status of our Reserve, we provide a summary of all the obligations and assets within it. Then for convenience's sake we compute the value of each our holdings in all of the currencies we support, making it easy for example to display our total US dollar liabilities, but expressed in Euros. For example, a request to fetch a summary will return an array of assets with the following properties:
+To assist developers with tracking the overall status of our Reserve, we provide a summary of all the obligations and assets within it.
+Then for convenience's sake we compute the value of each our holdings in all of the currencies we support, making it easy for example to display our total US dollar liabilities, but expressed in Euros.
+For example, a request to fetch a summary will return an array of assets with the following properties:
 
 Property | Description
 -------- | ------------------------------------------------------------------------------
@@ -293,7 +298,11 @@ To access this endpoint, an API key is required.
 
 ### Deposits
 
-The following entry shows how a deposit of 0.5 bitcoin by a user would be encoded on the Reserveledger. Every deposit results in two entries in the ledger. The first records the acquisition of a liability, and the second the genesis of an asset. Specifically, it shows the creation of 0.5 bitcoin as an obligation to the user, plus the acquisition of 0.5 bitcoin as an asset.
+The following entry shows how a deposit of 0.5 bitcoin by a user would be encoded on the Reserveledger.
+Every deposit results in two entries in the ledger.
+The first records the acquisition of a liability, and the second the genesis of an asset.
+Specifically, it shows the creation of 0.5 bitcoin as an obligation to the user, plus the acquisition of 0.5 bitcoin as an asset.
+
 <pre class="inline"><code>{
   "type": "liability",
   "out": {
@@ -323,7 +332,12 @@ The following entry shows how a deposit of 0.5 bitcoin by a user would be encode
 
 ### Transfer of Value
 
-The entry below shows how a user transferring 1.3 bitcoin to a "dollar card", effectively exchanging bitcoin for dollars, would be encoded on the ledger. In this entry, two liabilities are affected. The first is a loss of 1.3 BTC as an obligation, and the second is a gain of $507.51 USD as an obligation. Which makes sense: when a user transfers the bitcoin to their dollar card, Uphold no longer owes them that bitcoin. Instead, Uphold owes them the $507.51 they exchanged for that bitcoin.
+The entry below shows how a user transferring 1.3 bitcoin to a "dollar card", effectively exchanging bitcoin for dollars, would be encoded on the ledger.
+In this entry, two liabilities are affected.
+The first is a loss of 1.3 BTC as an obligation, and the second is a gain of $507.51 USD as an obligation.
+Which makes sense: when a user transfers the bitcoin to their dollar card, Uphold no longer owes them that bitcoin.
+Instead, Uphold owes them the $507.51 they exchanged for that bitcoin.
+
 <pre class="inline"><code>{
   "type": "liability",
   "out": {
@@ -339,7 +353,12 @@ The entry below shows how a user transferring 1.3 bitcoin to a "dollar card", ef
 }
 </code></pre>
 
-This transfer of value affects our liabilities immediately and in real-time, and thus is reflected in real-time in the ledger. But when our obligations to our members change a possible imbalance in our Reserve is introduced. To compensate for this, we must make changes to the assets as well. These changes to our assets may or may not happen in real-time. This would therefore be recorded in our ledger at some point in the future as follows:
+This transfer of value affects our liabilities immediately and in real-time, and thus is reflected in real-time in the ledger.
+But when our obligations to our members change a possible imbalance in our Reserve is introduced.
+To compensate for this, we must make changes to the assets as well.
+These changes to our assets may or may not happen in real-time.
+This would therefore be recorded in our ledger at some point in the future as follows:
+
 <pre class="inline"><code>{
   "type": "asset",
   "out": {
@@ -354,11 +373,16 @@ This transfer of value affects our liabilities immediately and in real-time, and
 }
 </code></pre>
 
-The examples above are nearly identical from one another due to the simplicity of the use case it elucidates. Consider however that when operating normally it is likely that a series of changes to our liabilities will be aggregated and accounted for in a single change to our assets in order to restore balance to the reserve.
+The examples above are nearly identical from one another due to the simplicity of the use case it elucidates.
+Consider however that when operating normally it is likely that a series of changes to our liabilities will be aggregated and accounted for in a single change to our assets in order to restore balance to the reserve.
 
 ### Withdrawal of Bitcoin
 
-When value is removed from the Reserve, two entries are added. One accounting for the change in assets, and the other for the change in liabilities. The following entry shows how a user transmitting some bitcoin to an external network/wallet would be encoded on the ledger. It shows the removal of a liability of bitcoin to the user, and the subsequent removal of bitcoin as an asset.
+When value is removed from the Reserve, two entries are added.
+One accounting for the change in assets, and the other for the change in liabilities.
+The following entry shows how a user transmitting some bitcoin to an external network/wallet would be encoded on the ledger.
+It shows the removal of a liability of bitcoin to the user, and the subsequent removal of bitcoin as an asset.
+
 <pre class="inline"><code>{
   "type": "asset",
     "out": {
@@ -388,7 +412,12 @@ When value is removed from the Reserve, two entries are added. One accounting fo
 
 ### Reallocation of Assets
 
-Uphold may decide to secure the value of its Reserve by holding value in asset classes which may or may not correlate to how our liabilities are denominated among our members. For example, Uphold may wish to convert $1,000,000 in cash into a security of equal value. These changes to the Reserve do not relate to any specific transaction, but need to be accounted for nonetheless. What follows is how we could encode shifting 1M dollars into a US Treasury Bill. Take note that we can optionally include additional data relating to the asset class.
+Uphold may decide to secure the value of its Reserve by holding value in asset classes which may or may not correlate to how our liabilities are denominated among our members.
+For example, Uphold may wish to convert $1,000,000 in cash into a security of equal value.
+These changes to the Reserve do not relate to any specific transaction, but need to be accounted for nonetheless.
+What follows is how we could encode shifting 1M dollars into a US Treasury Bill.
+Take note that we can optionally include additional data relating to the asset class.
+
 <pre class="inline"><code>{
   "type": "asset",
   "out": {
@@ -415,7 +444,8 @@ Uphold may decide to secure the value of its Reserve by holding value in asset c
 
 ## The Reservechain
 
-Uphold's Reservechain is a record of all of the transactions made by its Members that move value through the network. It is a "chain" in that any value moved in a transaction can be easily traced back to it's origin.
+Uphold's Reservechain is a record of all of the transactions made by its Members that move value through the network.
+It is a "chain" in that any value moved in a transaction can be easily traced back to it's origin.
 
 At a high level, each transaction in the Reservechain contains the following key pieces of information:
 
@@ -431,17 +461,23 @@ At a high level, each transaction in the Reservechain contains the following key
 
 ### Traceability
 
-Just like a block chain, the Reservechain is both completely transparent, and **traceable**. For a transaction to be traceable, the value encapsulated by the transaction must reference all the places within the chain where that value is drawn from. This is done by providing a list of transaction IDs, and the value drawn from each. By following these transactions you walk backwards down different paths of the Reservechain until you ultimately find a genesis point for all value accounted for in the transaction.
+Just like a block chain, the Reservechain is both completely transparent, and **traceable**.
+For a transaction to be traceable, the value encapsulated by the transaction must reference all the places within the chain where that value is drawn from.
+This is done by providing a list of transaction IDs, and the value drawn from each.
+By following these transactions you walk backwards down different paths of the Reservechain until you ultimately find a genesis point for all value accounted for in the transaction.
 
 ### Security and Privacy
 
-All transactions are made public, but specific details about the transaction may be withheld from parties who were not a party to said transaction. To control this we would require developers to authenticate prior to retrieving privileged information relating to a transaction.
+All transactions are made public, but specific details about the transaction may be withheld from parties who were not a party to said transaction.
+To control this we would require developers to authenticate prior to retrieving privileged information relating to a transaction.
 
 ### Deposits
 
 A deposit relates to two things: the adding of value into the Reservechain from the outside, and the creation of a new obligation to a user.
 
-Given that this is a point in the chain at which there is a genesis of value, there are no subsequent transactions within the Reservechain to link backwards to. However, we will provide a link to the external authority documenting the source of the value whenever possible.
+Given that this is a point in the chain at which there is a genesis of value, there are no subsequent transactions within the Reservechain to link backwards to.
+However, we will provide a link to the external authority documenting the source of the value whenever possible.
+
 <pre class="inline"><code>{
   "id": "e205b50e-6649-416d-82c1-98f0ba44dcd9",
   "type": "deposit",
@@ -480,9 +516,11 @@ Given that this is a point in the chain at which there is a genesis of value, th
 
 ### Withdrawals
 
-Withdrawal documents the flow of assets out of the system. The destination of the transaction would refer as completely as it can to any external sources that the Uphold transaction can be correlated against/with.
+Withdrawal documents the flow of assets out of the system.
+The destination of the transaction would refer as completely as it can to any external sources that the Uphold transaction can be correlated against/with.
 
 Withdrawals also account for value leaving the Reservechain, and is thus a terminus point with regards to traceability.
+
 <pre class="inline"><code>{
   "id": "6ab1f3e8-3b84-40b0-aec7-8008117c9f86",
   "type": "withdrawal",
@@ -526,6 +564,7 @@ Withdrawals also account for value leaving the Reservechain, and is thus a termi
 ### Transfers
 
 A transfer documents movement of value within our network, either between two parties or two denominations, or both.
+
 <pre class="inline"><code>{
   "id": "1571fbef-d34e-447c-9b6e-4ad775953082",
   "type": "transfer",
@@ -570,6 +609,7 @@ A transfer documents movement of value within our network, either between two pa
 
 ## Privacy
 
-The Reservechain is a public resource, and is 100% anonymous. **At no point does the Reservechain expose any personally identifiable information**, or any information that could be directly tied to an identity with our network.
+The Reservechain is a public resource, and is 100% anonymous.
+**At no point does the Reservechain expose any personally identifiable information**, or any information that could be directly tied to an identity with our network.
 
 We may disclose personally identifiable information to those who were a party to a transaction by way of the protected [List User Transactions](#list-user-transactions) and [List Card Transactions](#list-card-transactions) endpoints.

--- a/_transparency.md
+++ b/_transparency.md
@@ -254,7 +254,7 @@ curl https://api.uphold.com/v0/reserve/statistics
 ```
 
 To assist developers with tracking the overall status of our Reserve, we provide a summary of all the obligations and assets within it.
-Then for convenience's sake we compute the value of each our holdings in all of the currencies we support, making it easy for example to display our total US dollar liabilities, but expressed in Euros.
+Then, for convenience's sake, we compute the value of each our holdings in all of the currencies we support, making it easy for example to display our total US dollar liabilities, but expressed in Euros.
 For example, a request to fetch a summary will return an array of assets with the following properties:
 
 Property | Description
@@ -354,7 +354,7 @@ Instead, Uphold owes them the $507.51 they exchanged for that bitcoin.
 </code></pre>
 
 This transfer of value affects our liabilities immediately and in real-time, and thus is reflected in real-time in the ledger.
-But when our obligations to our members change a possible imbalance in our Reserve is introduced.
+But when our obligations to our members change, a possible imbalance in our Reserve is introduced.
 To compensate for this, we must make changes to the assets as well.
 These changes to our assets may or may not happen in real-time.
 This would therefore be recorded in our ledger at some point in the future as follows:
@@ -469,7 +469,7 @@ By following these transactions you walk backwards down different paths of the R
 ### Security and Privacy
 
 All transactions are made public, but specific details about the transaction may be withheld from parties who were not a party to said transaction.
-To control this we would require developers to authenticate prior to retrieving privileged information relating to a transaction.
+To control this, we require developers to authenticate prior to retrieving privileged information relating to a transaction.
 
 ### Deposits
 

--- a/_users.md
+++ b/_users.md
@@ -96,7 +96,8 @@ See the [user object](#user-object) documentation for details about the format o
 
 ### Cards
 
-The `cards` property will be removed from the response. To access the cards of a given user please refer to the appropriate specific [endpoint](#list-cards).
+The `cards` property will be removed from the response.
+To access the cards of a given user please refer to the appropriate specific [endpoint](#list-cards).
 
 ## Get User Phone Numbers
 

--- a/_users.md
+++ b/_users.md
@@ -91,7 +91,7 @@ Returns the data associated with the current user.
 See the [user object](#user-object) documentation for details about the format of the response.
 
 <aside class="notice">
-  Be advised that this method has the potential to return a great deal of data.
+  Be advised that this method can potentially return a large amount of data.
 </aside>
 
 ### Cards

--- a/_webhooks.md
+++ b/_webhooks.md
@@ -1,12 +1,12 @@
 # Webhooks
 
 For **business usage only** you may choose to use webhooks to get updates in real time instead of having to poll the API.
-This requires manual approval from Uphold.
+This requires [manual approval](#support) from Uphold.
 
 A webhooks integration requires the following details:
 
 * **Subscription URL:** the URL for Uphold to send webhook requests to;
-* **Secret:** the secret for Uphold to use to sign all requests and prove they have not been tampered
+* **Secret:** the secret for Uphold to use to sign all requests and prove they have not been tampered with
   (not the same as the client secret that is used for Uphold's API).
 
 Each webhook uses the following format:
@@ -26,7 +26,7 @@ userId    | Unique identifier of the Uphold user that owns the resource.
 sha512=040518ad86dd4bea08ba6d23240f53a9f35175bcb3c548e83f33acc792aabcafe29954f92b0e1d6ede9192c851b3ba0768f760f516e168c7b318a17d2714bf52
 ```
 
-In addition, the request also includes a signature header, that can be used to verify the request body has not been tampered.
+In addition, the request also includes a signature header, that can be used to verify the request body has not been tampered with.
 That header is built by signing the request body with the previously provided secret, using the SHA512 algorithm.
 
 ## Card Updated

--- a/_webhooks.md
+++ b/_webhooks.md
@@ -1,11 +1,13 @@
 # Webhooks
 
-For **business usage only** you may choose to use webhooks to get updates in real time instead of having to poll the API. This requires manual approval from Uphold.
+For **business usage only** you may choose to use webhooks to get updates in real time instead of having to poll the API.
+This requires manual approval from Uphold.
 
 A webhooks integration requires the following details:
 
 * **Subscription URL:** the URL for Uphold to send webhook requests to;
-* **Secret:** the secret for Uphold to use to sign all requests and prove they have not been tampered (not the same as the client secret that is used for Uphold's API).
+* **Secret:** the secret for Uphold to use to sign all requests and prove they have not been tampered
+  (not the same as the client secret that is used for Uphold's API).
 
 Each webhook uses the following format:
 
@@ -24,7 +26,8 @@ userId    | Unique identifier of the Uphold user that owns the resource.
 sha512=040518ad86dd4bea08ba6d23240f53a9f35175bcb3c548e83f33acc792aabcafe29954f92b0e1d6ede9192c851b3ba0768f760f516e168c7b318a17d2714bf52
 ```
 
-In addition, the request also includes a signature header, that can be used to verify the request body has not been tampered. That header is built by signing the request body with the previously provided secret, using the SHA512 algorithm.
+In addition, the request also includes a signature header, that can be used to verify the request body has not been tampered.
+That header is built by signing the request body with the previously provided secret, using the SHA512 algorithm.
 
 ## Card Updated
 
@@ -49,7 +52,8 @@ In addition, the request also includes a signature header, that can be used to v
 
 ```
 
-Returns the card details and context whenever a card has changed its `available` or `balance`, i.e. whenever it sends or receives a transaction. The context includes the id of that transaction.
+Returns the card details and context whenever a card has changed its `available` or `balance`, i.e. whenever it sends or receives a transaction.
+The context includes the id of that transaction.
 
 This webhook returns the following payload:
 


### PR DESCRIPTION
This is a grab-bag of small improvements across various sections of the documentation, that didn't warrant individual PRs.

**Note for reviewers:** the first commit of this PR adds a bunch of line breaks; no content is changed, but the breaks confuse most diffing tools, so I recommend reviewing the second commit separately, which will allow the actual content changes to be properly highlighted.
