### PR TITLE
Add deprecation notice for card `settings.position`

### DIFF
--- a/_cards.md
+++ b/_cards.md
@@ -190,7 +190,9 @@ curl https://api.uphold.com/v0/me/cards/37e002a7-8508-4268-a18c-7335a6ddf24b \
 Parameter | Description
 --------- | -----------------------------------------------------------------
 label     | The display name of the card. Max length: 140 characters.
-settings  | An object with the card's `position` and whether it is `starred`.
+settings  | This property contains the following keys:
+|         | `starred`: Indicates whether the card is starred or not.
+|         | <code class="notice">DEPRECATED</code> `position`: The card's current position.
 
 ### Response
 

--- a/_entities.md
+++ b/_entities.md
@@ -88,7 +88,9 @@ currency          | The currency by which the card is denominated.
 id                | A unique ID associated with the card.
 label             | The display name of the card as chosen by the user.
 lastTransactionAt | A timestamp of the last time a transaction on this card was conducted.
-settings          | Contains the card's current `position` and whether the card is `starred` or not.
+settings          | This property contains the following keys:
+|                 | `starred`: Indicates whether the card is `starred` or not.
+|                 | <code class="notice">DEPRECATED</code> `position`: The card's current position.
 normalized        | Contains the normalized `available` and `balance` values in the currency set by the user in the settings.
 
 ## Contact Object


### PR DESCRIPTION
This PR adds a deprecation notice for the `settings.position` property of a card entity.

- Blocked by https://github.com/uphold/slate/pull/79.

![image](https://user-images.githubusercontent.com/3464842/137155694-458c4969-811b-4f6e-9ef2-ce6fb6a5986d.png)