### PR TITLE
Remove `OTP-method-id` from docs

### DIFF
--- a/_authentication.md
+++ b/_authentication.md
@@ -200,7 +200,6 @@ To list Personal Access Tokens you may use the following endpoint:
 curl https://api.uphold.com/v0/me/tokens \
   -X POST \
   -H "Content-Type: application/json" \
-  -H "OTP-Method-Id: <Method-Id>" \
   -H "OTP-Token: <OTP-Token>" \
   -u <email>:<password> \
   -d '{ "description": "My command line script" }'
@@ -227,7 +226,7 @@ Parameter   | Required | Description
 description | yes      | A human-readable description of this PAT.
 
 <aside class="notice">
-  Requires the <code>OTP-Method-Id</code> header with the id of a verified authentication method that belongs to the user, and the <code>OTP-Token</code> header with a valid TOTP token associated to that authentication method.
+  Requires the <code>OTP-Token</code> header with a valid TOTP token.
 </aside>
 
 ### Revoking a PAT
@@ -269,12 +268,11 @@ The `<token>` should be set as the `accessToken` received during creation.
 
 ```bash
 curl https://api.uphold.com/v0/me \
-  -H 'OTP-Method-Id: <Method-Id>' \
   -H 'OTP-Token: <OTP-Token>' \
   -u <email>:<password>
 ```
 
 You can use Basic Authentication by providing your email and password combination.
 
-If OTP (One-Time Password, also known as Two-Factor Authentication) is required, then you will get a [401 HTTP error](#errors), along with the HTTP header `OTP-Token: Required` and/or `OTP-Method-Id: Required`.
-In which case, execute the command above again, this time passing your OTP verification code and method id as headers, like so: `OTP-Token: <OTP-Token>` and `OTP-Method-Id: <OTP-Method-Id>`.
+If OTP (One-Time Password, also known as Two-Factor Authentication) is required, then you will get a [401 HTTP error](#errors), along with the HTTP header `OTP-Token: Required`.
+In which case, execute the command above again, this time passing your OTP verification code header, like so: `OTP-Token: <OTP-Token>`.

--- a/_totp.md
+++ b/_totp.md
@@ -48,7 +48,6 @@ Returns an array of the current user's authentication methods.
 curl https://api.uphold.com/v0/me/authentication_methods/totp \
   -X POST \
   -H "Authorization: Bearer <token>" \
-  -H 'OTP-Method-Id: <OTP-Method-Id>'
   -H 'OTP-Token: <OTP-Token>'
 ```
 
@@ -71,7 +70,7 @@ curl https://api.uphold.com/v0/me/authentication_methods/totp \
 `POST https://api.uphold.com/v0/me/authentication_methods/totp`
 
 <aside class="notice">
-  Requires the <code>OTP-Method-Id</code> header with the id of a verified authentication method that belongs to the user, and the <code>OTP-Token</code> header with a valid TOTP token associated to that authentication method.
+  Requires the <code>OTP-Token</code> header with a valid TOTP token.
 </aside>
 
 ### Response
@@ -116,7 +115,6 @@ curl https://api.uphold.com/v0/me/authentication_methods/3f8f8264-2f5e-4b2b-8333
   -X DELETE \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -H "OTP-Method-Id: <Method-Id>" \
   -H "OTP-Token: <OTP-Token>"
 ```
 
@@ -127,10 +125,7 @@ curl https://api.uphold.com/v0/me/authentication_methods/3f8f8264-2f5e-4b2b-8333
 `DELETE https://api.uphold.com/v0/me/authentication_methods/3f8f8264-2f5e-4b2b-8333-473715ab039a`
 
 <aside class="notice">
-  Requires the <code>OTP-Method-Id</code> header to be sent with the id of a verified authentication method that belongs to the user.
-</aside>
-<aside class="notice">
-  Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token, belonging to the authentication method specified in <code>OTP-Method-Id</code>.
+  Requires the <code>OTP-Token</code> header to be sent with a valid TOTP token.
 </aside>
 <aside class="notice">
   You cannot delete all of a user's authentication methods as trying to delete the last verified method of a user will return an error.

--- a/_transactions.md
+++ b/_transactions.md
@@ -179,9 +179,9 @@ Once the transaction is committed, its status will change to `processing`.
 </aside>
 <aside class="notice">
   If the <a href="#permissions"><code>transactions:commit:otp</code> permission</a> has been granted by the user, and an OTP is not provided with the request,
-  you will get a <a href="#errors">401 HTTP error</a>, along with the HTTP header <code>OTP-Token: Required</code> and/or <code>OTP-Method-Id: Required</code>.
-  In that case, re-send the request, including the OTP verification code and method id as headers, like so:
-  <code>OTP-Token: &lt;OTP-Token&gt;</code> and <code>OTP-Method-Id: &lt;OTP-Method-Id&gt;</code>.
+  you will get a <a href="#errors">401 HTTP error</a>, along with the HTTP header <code>OTP-Token: Required</code>.
+  In that case, re-send the request, including the OTP verification code like so:
+  <code>OTP-Token: &lt;OTP-Token&gt;</code>.
 </aside>
 
 ### Request
@@ -435,7 +435,6 @@ curl 'https://api-sandbox.uphold.com/v0/me/cards/<card-id>/transactions' \
 curl 'https://api-sandbox.uphold.com/v0/me/cards/<card-id>/transactions/<transaction-id>/commit' \
   -H 'Authorization: Bearer <bearer-token>' \
   -H 'Content-Type: application/json' \
-  -H 'OTP-Method-Id: <Method-Id>' \
   -H 'OTP-Token: <OTP-Token>' \
   -d '{
     "beneficiary": {


### PR DESCRIPTION
This PR removes all mentions of `OTP-method-id` from the API docs.